### PR TITLE
Huge refactor, bug fixes, new text route, changed JS to TS. Moved and improved services.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -57,6 +57,11 @@ ul {
   min-width: 30ch;
 }
 
+.textList a {
+  color: inherit; /* blue colors for links too */
+  text-decoration: inherit; /* no underline */
+}
+
 .newTextForm {
   width: 30%;
   display: flex;

--- a/src/App.css
+++ b/src/App.css
@@ -26,10 +26,16 @@ ul {
 
 .Text-page {
   display: flex;
+  flex-direction: column;
   font-size: 1.2rem;
   align-items: flex-start;
   /* padding: 1rem; */
   justify-content: space-evenly;
+}
+
+.single-text-page {
+  display: flex;
+  flex-direction: row;
 }
 
 .user-input-div {

--- a/src/App.css
+++ b/src/App.css
@@ -96,9 +96,17 @@ li {
   background-color: #61dafb;
   width: 30vw;
   padding: 2rem;
+  position: absolute;
+  right: 0px;
 }
 
 .navBar {
   display: flex;
-  align-items: flex-start;
+  align-items: baseline;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.nav-languages {
+  display: flex;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,40 +8,38 @@ import { RecoilRoot } from 'recoil';
 import Home from './components/Home';
 import About from './components/About';
 import Settings from './components/Settings';
-import Texts from './components/Texts';
 import Words from './components/Words';
 import LogIn from './components/LogIn';
 import SignUp from './components/SignUp';
 import SingleText from './components/texts/SingleText';
-// import UserContext from './contexts/UserContext';
 import './App.css';
+import UserTexts from './components/texts/UserTexts';
 
 function App() {
-  // const [user, setUser] = useState(null);
-  // const providerValue = useMemo(() => ({ user, setUser }), [user, setUser]);
-
-  // if (!user) {
-  //   return <LogIn setUser={setUser} />;
-  // }
-
   return (
     <Router>
       <div className="app">
-        {/* <UserContext.Provider value={providerValue}> */}
         <RecoilRoot>
           <Routes>
             <Route path="/" element={<Home />} />
-            <Route path="/texts" element={<Texts />} />
-            <Route path="/texts/:textId" element={<SingleText />} />
-            <Route path="/words" element={<Words />} />
-            <Route path="/signup" element={<SignUp />} />
-            <Route path="/login" element={<LogIn />} />
-            <Route path="/logout" element={<Home />} />
-            <Route path="/settings" element={<Settings />} />
-            <Route path="/about" element={<About />} />
+              <Route path="texts/" element={<UserTexts />} />
+              <Route path="texts/:textId" element={<SingleText />} />
+              <Route path="words" element={<Words />} />
+              <Route path="signup" element={<SignUp />} />
+              <Route path="login" element={<LogIn />} />
+              <Route path="logout" element={<Home />} />
+              <Route path="settings" element={<Settings />} />
+              <Route path="about" element={<About />} />
+              <Route
+                path="*"
+                element={
+                  <main>
+                    <p>There's nothing here!</p>
+                  </main>
+                }
+              />
           </Routes>
         </RecoilRoot>
-        {/* </ UserContext.Provider> */}
       </div>
     </Router>
   );

--- a/src/components/Languages.tsx
+++ b/src/components/Languages.tsx
@@ -86,6 +86,7 @@ export default function Languages({ setShowLanguages }: { setShowLanguages: Func
 
   return (
     <form className='langForm' onSubmit={(event) => setUserLanguagesOnServer(event)}>
+      <p onClick={() => setShowLanguages(false)}>X</p>
       <p>I know:</p>
       {currentKnownLanguageId && <select value={currentKnownLanguageId} onChange={(event) => setCurrentKnownLanguageId(event.target.value)} name="" id="">
         {languages.map((lang) => <option key={lang.id} value={lang.id} >{lang.name}</option>)}

--- a/src/components/LogIn.tsx
+++ b/src/components/LogIn.tsx
@@ -1,5 +1,5 @@
 import Nav from './Nav';
-import LoginForm from '../utils/loginForm';
+import LoginForm from './loginForm';
 import getToken from '../utils/getToken';
 
 export default function LogIn() {

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -11,9 +11,7 @@ export default function Nav() {
   const [showLanguages, setShowLanguages] = useState(false);
 
   return (
-    <div>
-      <div>
-        <div>
+    <>
           {tokenObj ? (
             <div className='navBar'>
               <ul>
@@ -23,9 +21,9 @@ export default function Nav() {
                 <li><NavLink to='/settings'>Setting</NavLink></li>
                 <li><NavLink to='/' onClick={() => logOut()}>Log out</NavLink></li>
               </ul>
-              <ul>
+              <ul className='nav-languages'>
                 <li>
-                  <p onClick={() => setShowLanguages(true)}>Click to set Languages</p>
+                  <p onClick={() => setShowLanguages(true)}>Languages</p>
                     {showLanguages && <Languages setShowLanguages={setShowLanguages}/>}
                 </li>
               </ul>
@@ -40,9 +38,7 @@ export default function Nav() {
               <li><NavLink to='/about'>About</NavLink></li>
             </ul>
           )}
-        </div>
-      </div>
       <Outlet />
-    </div>
+    </>
   );
 }

--- a/src/components/Texts.tsx
+++ b/src/components/Texts.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { useRecoilValue } from 'recoil';
 
 import SingleText from './texts/SingleText';
@@ -8,11 +9,11 @@ import { currenttextState } from '../states/recoil-states';
 const TextsPage = function() {
   const currentText = useRecoilValue(currenttextState);
 
-  if (currentText) {
-    return (
-      <SingleText />
-    );
-  }
+  // if (currentText) {
+  //   return (
+  //     <SingleText />
+  //   );
+  // }
 
   return (
     <UserTexts />

--- a/src/components/loginForm.tsx
+++ b/src/components/loginForm.tsx
@@ -1,34 +1,26 @@
-import { useState } from 'react';
-import axios from 'axios';
+import { FormEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import { currentUserLanguagesState } from '../states/recoil-states';
-
-// import UserContext from '../contexts/UserContext';
-
-const loginUser = async function(credentials) {
-  const request = await axios.post('http://localhost:3000/api/login', credentials).then((response) => response);
-  return request;
-};
+import loginService from '../services/login';
+import { User } from '../types';
 
 export default function LoginForm() {
-  const [email, setEmail] = useState();
-  const [password, setPassword] = useState();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
   const setCurrentUserLanguages = useSetRecoilState(currentUserLanguagesState);
 
-  // const { user, setUser } = useContext(UserContext);
   const navigate = useNavigate();
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
 
     try {
-      const response = await loginUser({
+      const user: User = await loginService.loginUser({
         email,
         password,
       });
 
-      const user = response.data;
       localStorage.setItem('user', JSON.stringify(user));
 
       const currentUserLangs = {
@@ -38,9 +30,9 @@ export default function LoginForm() {
 
       setCurrentUserLanguages(currentUserLangs);
       navigate('/texts');
-    // eslint-disable-next-line @typescript-eslint/no-shadow
-    } catch (e) {
-      alert(e.message);
+    } catch (error) {
+      // eslint-disable-next-line no-alert
+      alert(error);
     }
   };
 
@@ -48,7 +40,7 @@ export default function LoginForm() {
   return (
     <div className="login-wrapper">
       <h1>Please Log In</h1>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={(event) => handleSubmit(event)}>
         <label>
           <p>Email</p>
           <input type="text" onChange={(e) => setEmail(e.target.value)}/>

--- a/src/components/texts/SingleText.tsx
+++ b/src/components/texts/SingleText.tsx
@@ -23,7 +23,7 @@ const SingleText = function () {
     };
 
     fetchUserwords();
-  }, []);
+  }, [currentText]);
 
   if (currentText) {
     return (

--- a/src/components/texts/SingleText.tsx
+++ b/src/components/texts/SingleText.tsx
@@ -1,28 +1,40 @@
-/* eslint-disable max-len */
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import Nav from '../Nav';
 import TranslationInput from './TranslationInput';
 import TextBody from './Body-Paragraph';
-
 import wordsService from '../../services/words';
-
+import textsService from '../../services/texts';
 import { userwordsState, currenttextState, currentwordState } from '../../states/recoil-states';
 
 const SingleText = function () {
-  const currentText = useRecoilValue(currenttextState);
+  const [currentText, setCurrentText] = useRecoilState(currenttextState);
   const currentWord = useRecoilValue(currentwordState);
   const setUserWords = useSetRecoilState(userwordsState);
+  const params = useParams();
+
+  const fetchUserwords = async function() {
+    if (currentText) {
+      const userWordsResponse = await wordsService
+        .getUserwordsInText(String(currentText.id), currentText.languageId);
+      setUserWords(userWordsResponse);
+    }
+  };
+
+  const getTextById = async function() {
+    if (params.textId) {
+      const text = await textsService.getTextById(params.textId);
+      setCurrentText(text);
+    }
+  };
 
   useEffect(() => {
-    const fetchUserwords = async function() {
-      if (currentText) {
-        const userWordsResponse = await wordsService.getUserwordsInText(String(currentText.id), currentText.languageId);
-        setUserWords(userWordsResponse);
-      }
-    };
-
-    fetchUserwords();
+    if (currentText) {
+      fetchUserwords();
+    } else {
+      getTextById();
+    }
   }, [currentText]);
 
   if (currentText) {
@@ -44,7 +56,8 @@ const SingleText = function () {
     <div className='Text-page'>
       <Nav />
       <div className='text-div'>
-        <h1>No text found.</h1>
+        <h1>No text found. (This sometimes appears when a text is being loaded from the server,
+          it will be replaced later by a placeholder)</h1>
       </div>
     </div>
   );

--- a/src/components/texts/SingleText.tsx
+++ b/src/components/texts/SingleText.tsx
@@ -19,6 +19,7 @@ const SingleText = function () {
     const fetchUserwords = async function() {
       if (currentText) {
         const userWordsResponse = await wordsService.getUserwordsInText(String(currentText.id), currentText.languageId);
+        console.log(userWordsResponse);
         setUserWords(userWordsResponse);
       }
     };
@@ -29,12 +30,14 @@ const SingleText = function () {
   if (currentText) {
     return (
       <div className='Text-page'>
-        {/* <Nav /> */}
-        <div className='text-div'>
-          <h1>{currentText.title}</h1>
-          <TextBody textBody={currentText.body} />
+        <Nav />
+        <div className='single-text-page'>
+          <div className='text-div'>
+            <h1>{currentText.title}</h1>
+            <TextBody textBody={currentText.body} />
+          </div>
+          <TranslationInput word={currentWord}/>
         </div>
-        <TranslationInput word={currentWord}/>
       </div>
     );
   }

--- a/src/components/texts/SingleText.tsx
+++ b/src/components/texts/SingleText.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable max-len */
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { useEffect } from 'react';
-
 import Nav from '../Nav';
 import TranslationInput from './TranslationInput';
 import TextBody from './Body-Paragraph';
@@ -19,7 +18,6 @@ const SingleText = function () {
     const fetchUserwords = async function() {
       if (currentText) {
         const userWordsResponse = await wordsService.getUserwordsInText(String(currentText.id), currentText.languageId);
-        console.log(userWordsResponse);
         setUserWords(userWordsResponse);
       }
     };

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -103,7 +103,7 @@ const TranslationComponent = function({ word }: { word: UserWord | null }) {
     <div className="translation-div">
       {word && word?.translations?.length > 0
       && <p>Current translation: {word?.translations.map((transObj) => `${transObj.translation || transObj}, `)}</p>}
-      {currentWord && <iframe width="350" height="500" src={`https://www.wordreference.com/${currentText?.languageId}en/${currentWord.word}`}></iframe>}
+      {currentWord && <iframe width="350" height="500" src={`https://www.wordreference.com/${currentText?.languageId}${currentUserLanguages?.currentKnownLanguageId}/${currentWord.word}`}></iframe>}
       <form onSubmit={(event) => {
         handleTranslation(event, translation, word);
         setTranslation('');

--- a/src/components/texts/UserTexts.tsx
+++ b/src/components/texts/UserTexts.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, FormEvent } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
+import { Link, Outlet } from 'react-router-dom';
 import textsService from '../../services/texts';
 import Nav from '../Nav';
 import { CurrentUserLanguages, Text } from '../../types';
@@ -21,8 +22,8 @@ const IndividualText = function({ text }: { text: Text }) {
   };
 
   return (
-    <li className='textItem'>
-      <h2><a href='#' onClick={(_event) => setCurrentText(text)}>{text.title}</a></h2>
+    <li className='textItem' >
+      <h2 onClick={(_event) => setCurrentText(text)}>{text.title}</h2>
       <p>{`${text.body.slice(0, 297)}...`}</p>
       <button onClick={() => removeTextFromServer(text.id)}>Delete</button>
     </li>
@@ -108,10 +109,11 @@ const UserTexts = function() {
         <Nav />
         {textList.length === 0 && <li>You have no texts, please add a text to begin.</li>}
         <NewTextForm submitText={submitText} newTextTitle={newTextTitle}
-        newText={newText} setNewTextTitle={setNewTextTitle} setNewText={setNewText} />
+          newText={newText} setNewTextTitle={setNewTextTitle} setNewText={setNewText} />
         <ul className='textList'>
-          {textList.map((text) => <IndividualText key={text.id} text={text} />)}
+          {textList.map((text) => <><Link key={text.id} to={`/texts/${text.id}`}><IndividualText key={text.id} text={text} /></Link></>)}
         </ul>
+        <Outlet />
       </div>
   );
 };

--- a/src/contexts/UserContext.js
+++ b/src/contexts/UserContext.js
@@ -1,6 +1,0 @@
-import { createContext } from 'react';
-
-const UserContext = createContext();
-
-export default UserContext;
-

--- a/src/services/login.ts
+++ b/src/services/login.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+import { LoginDetails } from '../types';
+
+const baseUrl = 'http://localhost:3000/api/login';
+
+const loginUser = async function(credentials: LoginDetails) {
+  const request = await axios.post(baseUrl, credentials);
+  return request.data;
+};
+
+export default {
+  loginUser,
+};

--- a/src/services/texts.ts
+++ b/src/services/texts.ts
@@ -28,7 +28,13 @@ const postNewText = async function(newText: Text) {
 };
 
 const getTextById = async function(id: string) {
-  const request = await axios.get(`${baseUrl}/${id}`);
+  const user = JSON.parse(localStorage.user);
+  const { token } = user;
+
+  const request = await axios.get(`${baseUrl}/${id}`, {
+    headers: { Authorization: `bearer ${token}` },
+  });
+
   return request.data;
 };
 

--- a/src/services/translations.ts
+++ b/src/services/translations.ts
@@ -7,12 +7,11 @@ const addTranslation = async function(translationObj: Translation) {
   const user = JSON.parse(localStorage.user);
   const { token } = user;
 
-  const request = await axios.post(`${baseUrl}`, translationObj, {
+  const response = await axios.post(`${baseUrl}`, translationObj, {
     headers: { Authorization: `bearer ${token}` },
   });
 
-  const response = request.data;
-  return response;
+  return response.data;
 };
 
 export default {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,8 +42,8 @@ export type User = {
   username: string,
   password: string,
   email: string,
-  currentKnownLanguageId?: string,
-  currentLearnLanguageId?: string,
+  currentKnownLanguageId: string,
+  currentLearnLanguageId: string,
 };
 
 export type LocalStorageUser = {
@@ -62,4 +62,9 @@ export type Translation = {
   translation: string,
   targetLanguageId: string,
   context: string,
+};
+
+export type LoginDetails = {
+  email: string,
+  password: string
 };


### PR DESCRIPTION
## Description

Added the navbar to single text page.
Added a route for `texts/:id`, edited styling.

Changed loginForm from JS to TSX, moved it to components folder. 
Removed optional tag on User type languageIds. 
Moved login service to /services.

Fixed bug where words were not always fetched from the server for user texts.
Added token to getTextById route. 

Fixed bug where a page reload on a text resulted in loss of context. 
User can now navigate directly to a text, e.g. `/texts/4`.

Fixed a bug where translations were not being saved. currentUserLanguages was sometimes undefined, meaning no api calls would go through. 

Also removed UserContext as it was no longer necessary.

Set WordReference to dynamically translate to the users 'known' language.

Improved navbar styling, languages is now a dropdown modal. Clicking the X closes the modal

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  X  | :bug: Bug fix              |
|  X  | :sparkles: New feature     |
|  X  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Testing Steps / QA Criteria

Navigate to a text, the navbar should be there.
Pressing the back key should go back to the list of texts.
Adding translations and statuses should work. They should persist even after a page refresh.
Word reference should respect the users known language choice.