### PR TITLE
Simplify logic of getting words and phrases. Removed unnecessary divs. Currently selected word is removed when user clicks on another word.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -94,10 +94,14 @@ li {
   display: flex;
   flex-direction: column;
   background-color: #61dafb;
-  width: 30vw;
+  width: 200px;
   padding: 2rem;
   position: absolute;
   right: 0px;
+}
+
+.langForm button {
+  margin: 1rem;
 }
 
 .navBar {

--- a/src/App.css
+++ b/src/App.css
@@ -41,6 +41,7 @@ ul {
 .user-input-div {
   /* max-width: 25%; */
   padding: 1rem;
+  /* width: 320px; */
   /* background-color: #61dafb; */
 }
 
@@ -71,7 +72,7 @@ ul {
 .text-div {
   /* max-width: 75%; */
   padding: 1.5rem;
-  /* background-color: #fb61c2; */
+  background-color: rgba(169, 169, 169, 0.479);
 }
 
 .change-status-div {

--- a/src/App.css
+++ b/src/App.css
@@ -39,10 +39,12 @@ ul {
 }
 
 .user-input-div {
-  /* max-width: 25%; */
   padding: 1rem;
-  /* width: 320px; */
-  /* background-color: #61dafb; */
+  width: 380px;
+  height: auto;
+  height: fit-content;
+  background-color: rgba(169, 169, 169, 0.459);
+  margin: 0 1rem;
 }
 
 .textList {
@@ -70,7 +72,8 @@ ul {
 }
 
 .text-div {
-  /* max-width: 75%; */
+  max-width: calc(100vw - 400px);
+  min-width: 350px;
   padding: 1.5rem;
   background-color: rgba(169, 169, 169, 0.479);
 }
@@ -83,9 +86,9 @@ ul {
   display: flex;
 }
 
-.translation-div {
+/* .translation-div {
   padding: 1rem;
-}
+} */
 
 li {
   margin-right: 10px;

--- a/src/components/Languages.tsx
+++ b/src/components/Languages.tsx
@@ -87,11 +87,11 @@ export default function Languages({ setShowLanguages }: { setShowLanguages: Func
   return (
     <form className='langForm' onSubmit={(event) => setUserLanguagesOnServer(event)}>
       <p onClick={() => setShowLanguages(false)}>X</p>
-      <p>I know:</p>
+      <label>I know:</label>
       {currentKnownLanguageId && <select value={currentKnownLanguageId} onChange={(event) => setCurrentKnownLanguageId(event.target.value)} name="" id="">
         {languages.map((lang) => <option key={lang.id} value={lang.id} >{lang.name}</option>)}
       </select>}
-      <p>I'm learning:</p>
+      <label>I'm learning:</label>
       {currentLearnLanguageId && <select value={currentLearnLanguageId} onChange={(event) => setCurrentLearnLanguageId(event.target.value)} name="" id="">
         {languages.map((lang) => <option key={lang.id} value={lang.id} >{lang.name}</option>)}
       </select>}

--- a/src/components/texts/Body-Paragraph.tsx
+++ b/src/components/texts/Body-Paragraph.tsx
@@ -1,11 +1,11 @@
 import {
-  selector, useRecoilValue, useRecoilState, useSetRecoilState,
+  selector, useRecoilValue,
 } from 'recoil';
 
 import { Word, Phrase } from './Phrase-Word';
 
 import {
-  markedwordsState, userwordsState, currentwordState, currentUserLanguagesState,
+  markedwordsState,
 } from '../../states/recoil-states';
 
 const phrasesState = selector({
@@ -15,7 +15,6 @@ const phrasesState = selector({
 
 const Paragraph = function({ paragraph }: { paragraph: string }) {
   const phrases = useRecoilValue(phrasesState);
-  const currentUserLanguages = useRecoilValue(currentUserLanguagesState);
 
   const phraseFinder = phrases.length === 0 ? '' : `(${phrases.join('|')})|`;
   const wordFinder = '(?<words>[\\p{Letter}\\p{Mark}\'-]+)';
@@ -26,49 +25,17 @@ const Paragraph = function({ paragraph }: { paragraph: string }) {
 
   const tokens = paragraph.match(tokenRegExp);
 
-  const [userWords, setUserWords] = useRecoilState(userwordsState);
-  const setCurrentWord = useSetRecoilState(currentwordState);
-
-  const handleWordClick = function(event: React.MouseEvent<HTMLSpanElement, MouseEvent>) {
-    const input = event.target as HTMLElement;
-    const word2 = input.textContent || '';
-
-    const wordObj = userWords.filter((arrWordObj) => arrWordObj.word.toLowerCase()
-      === word2.toLowerCase());
-
-    if (wordObj.length > 0) {
-      const wordObject = wordObj[0];
-
-      if (wordObject.status === undefined || wordObject.status === 'undefined') {
-        wordObject.status = 'learning';
-      }
-
-      const updatedWords = [...userWords.filter((arrWordObj) => arrWordObj.word.toLowerCase()
-        !== word2.toLowerCase()), wordObject];
-      setUserWords(updatedWords);
-      setCurrentWord(wordObject);
-    } else {
-      const newWordObj = {
-        word: `${word2.toLowerCase()}`, status: 'learning', translations: [], languageId: currentUserLanguages?.currentLearnLanguageId,
-      };
-
-      setCurrentWord(newWordObj);
-      const updatedWords = [...userWords, newWordObj];
-      setUserWords(updatedWords);
-    }
-  };
-
   return (
     <p>
       {
         tokens?.map((token, index) => {
           if (phrases.includes(token)) {
-            return <Phrase key={token + index} phrase={token} handleWordClick={handleWordClick} />;
+            return <Phrase key={token + index} phrase={token} />;
           }
 
           if (token.match(wordRegExp)) {
             return <Word key={token + index} dataKey={token + index}
-            word={token} handleWordClick={handleWordClick} />;
+            word={token} />;
           }
 
           return <span key={token + index}>{token}</span>;
@@ -79,12 +46,15 @@ const Paragraph = function({ paragraph }: { paragraph: string }) {
 };
 
 
-const TextBody = function ({ textBody }: { textBody: string }) {
+const TextBody = function ({ title, textBody }: { title: string, textBody: string }) {
   const paragraphs = textBody.split('\n');
 
   return (
     <>
       <div className="text-div">
+        { // title needs to be mapped so users can click on words in it
+        }
+        <h1>{title}</h1>
         {paragraphs.map((paragraph, index) => <Paragraph key={index} paragraph={paragraph} />)}
       </div>
     </>

--- a/src/components/texts/Body-Paragraph.tsx
+++ b/src/components/texts/Body-Paragraph.tsx
@@ -1,11 +1,13 @@
 import {
-  selector, useRecoilValue,
+  selector, useRecoilState, useRecoilValue,
 } from 'recoil';
 
 import { Word, Phrase } from './Phrase-Word';
 
 import {
+  currentwordState,
   markedwordsState,
+  userwordsState,
 } from '../../states/recoil-states';
 
 const phrasesState = selector({
@@ -45,13 +47,33 @@ const Paragraph = function({ paragraph }: { paragraph: string }) {
   );
 };
 
+const isElement = function(element: Element | EventTarget): element is Element {
+  return (element as Element).nodeName !== undefined;
+};
 
 const TextBody = function ({ title, textBody }: { title: string, textBody: string }) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [currentWord, setCurrentWord] = useRecoilState(currentwordState);
+  const [userWords, setUserWords] = useRecoilState(userwordsState);
   const paragraphs = textBody.split('\n');
+
+  const removeUnusedWord = function(event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
+    const { target }: { target: Element | EventTarget } = event;
+    // if a user clicks empty space inside the text div, the current word is removed
+    // if that word did not have a translation (or id) it is removed from userWords,
+    // removing the highlight
+    if (isElement(target) && target.nodeName !== 'SPAN') {
+      setCurrentWord(null);
+
+      const updatedWords = [...userWords
+        .filter((wordObj) => wordObj.id !== undefined)];
+      setUserWords(updatedWords);
+    }
+  };
 
   return (
     <>
-      <div className="text-div">
+      <div onClick={(event) => removeUnusedWord(event)} className="text-div">
         { // title needs to be mapped so users can click on words in it
         }
         <h1>{title}</h1>

--- a/src/components/texts/SingleText.tsx
+++ b/src/components/texts/SingleText.tsx
@@ -1,4 +1,4 @@
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import Nav from '../Nav';
@@ -10,7 +10,7 @@ import { userwordsState, currenttextState, currentwordState } from '../../states
 
 const SingleText = function () {
   const [currentText, setCurrentText] = useRecoilState(currenttextState);
-  const currentWord = useRecoilValue(currentwordState);
+  const [currentWord] = useRecoilState(currentwordState);
   const setUserWords = useSetRecoilState(userwordsState);
   const params = useParams();
 
@@ -42,10 +42,7 @@ const SingleText = function () {
       <div className='Text-page'>
         <Nav />
         <div className='single-text-page'>
-          <div className='text-div'>
-            <h1>{currentText.title}</h1>
-            <TextBody textBody={currentText.body} />
-          </div>
+          <TextBody title={currentText.title} textBody={currentText.body} />
           <TranslationInput word={currentWord}/>
         </div>
       </div>

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -1,5 +1,4 @@
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-
 import { ChangeEvent, useEffect, useState } from 'react';
 import {
   UserWord, Status, CurrentUserLanguages, Translation,
@@ -103,7 +102,9 @@ const TranslationComponent = function({ word }: { word: UserWord | null }) {
     <div className="translation-div">
       {word && word?.translations?.length > 0
       && <p>Current translation: {word?.translations.map((transObj) => `${transObj.translation || transObj}, `)}</p>}
-      {currentWord && <iframe width="350" height="500" src={`https://www.wordreference.com/${currentText?.languageId}${currentUserLanguages?.currentKnownLanguageId}/${currentWord.word}`}></iframe>}
+      {currentWord && <iframe width="350" height="500"
+        src={`https://www.wordreference.com/${currentText?.languageId}${currentUserLanguages?.currentKnownLanguageId}/${currentWord.word}`}>
+        </iframe>}
       <form onSubmit={(event) => {
         handleTranslation(event, translation, word);
         setTranslation('');
@@ -138,7 +139,7 @@ const ChangeStatus = function({ word }: { word: UserWord | null }) {
   };
 
   const wordStatusToolbar = word
-    ? <div className="word-status-toolbar">;
+    ? <div className="word-status-toolbar">
         <button onClick={() => setWordStatus('learning', word)} type={'button'}>Learning</button>
         <button onClick={() => setWordStatus('familiar', word)} type={'button'}>Familiar</button>
         <button onClick={() => setWordStatus('learned', word)} type={'button'}>Learned</button>


### PR DESCRIPTION
## Description

Greatly simplified word selection logic. 
Removed `handleClick`, renamed `getSelection` to `getWordOrPhrase`.

Now a word with no translation will be removed from userWords if another word is clicked.
Removed unnecessary divs from the TextBody component.

When a user clicks on the text div, but not on a word, the current word is deselected (and if it doesnt have a translation, it is removed from `userWords`).

Improved layout of single text page.

## Related Issue

Closes #42 

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  X  | :bug: Bug fix              |
|     | :sparkles: New feature     |
|  X | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Testing Steps / QA Criteria

Click on a word, then click another word without adding a translation. The word will no longer be selected.
Click on a word, then click anywhere on the text-div. The current word will be removed.