### PR TITLE
baseUrl depends on NODE_ENV now

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,7 @@
       { "argsIgnorePattern": "^_" }
     ],
     "no-case-declarations": "off",
+    "linebreak-style": "warn",
     "@typescript-eslint/func-names": ["off"],
     "func-names": ["off"],
     "@typescript-eslint/space-before-function-paren": ["off"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@types/react-dom": "^17.0.11",
         "@types/react-router-dom": "^5.3.2",
         "@types/recoil": "^0.0.9",
+        "cross-env": "^7.0.3",
         "eslint": "^8.4.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-airbnb-typescript": "^16.1.0",
@@ -5896,6 +5897,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -21128,6 +21147,15 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.7.2"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "dev": "cross-env NODE_ENV=development react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -55,6 +56,7 @@
     "@types/react-dom": "^17.0.11",
     "@types/react-router-dom": "^5.3.2",
     "@types/recoil": "^0.0.9",
+    "cross-env": "^7.0.3",
     "eslint": "^8.4.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^16.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "dev": "cross-env NODE_ENV=development react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -56,7 +55,6 @@
     "@types/react-dom": "^17.0.11",
     "@types/react-router-dom": "^5.3.2",
     "@types/recoil": "^0.0.9",
-    "cross-env": "^7.0.3",
     "eslint": "^8.4.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^16.1.0",

--- a/src/services/languages.ts
+++ b/src/services/languages.ts
@@ -1,10 +1,13 @@
 import axios from 'axios';
 import { Language } from '../types';
 
-const baseUrl = 'http://localhost:3000/api/languages';
+const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+
+const baseUrl = `${host}/api/languages`;
 
 const getAllLanguages = async function() {
-  const request = await axios.get(`${baseUrl}`);
+  console.log(host, process.env.NODE_ENV);
+  const request = await axios.get(`${baseUrl}/`);
 
   const languages: Array<Language> = request.data;
   return languages;

--- a/src/services/languages.ts
+++ b/src/services/languages.ts
@@ -6,7 +6,6 @@ const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 
 const baseUrl = `${host}/api/languages`;
 
 const getAllLanguages = async function() {
-  console.log(host, process.env.NODE_ENV);
   const request = await axios.get(`${baseUrl}/`);
 
   const languages: Array<Language> = request.data;

--- a/src/services/login.ts
+++ b/src/services/login.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 import { LoginDetails } from '../types';
 
-const baseUrl = 'http://localhost:3000/api/login';
+const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+
+const baseUrl = `${host}/api/login`;
 
 const loginUser = async function(credentials: LoginDetails) {
   const request = await axios.post(baseUrl, credentials);

--- a/src/services/texts.ts
+++ b/src/services/texts.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 import { Text } from '../types';
 
-const baseUrl = 'http://localhost:3000/api/texts';
+const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+
+const baseUrl = `${host}/api/texts`;
 
 const getAllUserTextsByLanguage = async function(languageId: string) {
   const user = JSON.parse(localStorage.user);

--- a/src/services/translations.ts
+++ b/src/services/translations.ts
@@ -1,13 +1,15 @@
 import axios from 'axios';
 import { Translation } from '../types';
 
-const baseUrl = 'http://localhost:3000/api/translations/';
+const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+
+const baseUrl = `${host}/api/translations`;
 
 const addTranslation = async function(translationObj: Translation) {
   const user = JSON.parse(localStorage.user);
   const { token } = user;
 
-  const response = await axios.post(`${baseUrl}`, translationObj, {
+  const response = await axios.post(`${baseUrl}/`, translationObj, {
     headers: { Authorization: `bearer ${token}` },
   });
 

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -1,10 +1,12 @@
 import axios from 'axios';
 import { CurrentUserLanguages, SanitizedUser, User } from '../types';
 
-const baseUrl = 'http://localhost:3000/api/users/';
+const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+
+const baseUrl = `${host}/api/users`;
 
 const addUser = async function(newUser: User) {
-  const response = await axios.post(`${baseUrl}`, newUser)
+  const response = await axios.post(`${baseUrl}/`, newUser)
     .then((res) => res)
     .catch((error) => {
       const { message } = error.response.data.error;
@@ -17,7 +19,7 @@ const setUserLanguages = async function(currentUserLanguages: CurrentUserLanguag
   const user = JSON.parse(localStorage.user);
   const { token } = user;
 
-  const request = await axios.put(`${baseUrl}set-languages`, currentUserLanguages, {
+  const request = await axios.put(`${baseUrl}/set-languages`, currentUserLanguages, {
     headers: { Authorization: `bearer ${token}` },
   });
 

--- a/src/services/words.ts
+++ b/src/services/words.ts
@@ -1,13 +1,15 @@
 import axios from 'axios';
 import { UserWord } from '../types';
 
-const baseUrl = 'http://localhost:3000/api/words/';
+const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+
+const baseUrl = `${host}/api/words`;
 
 const getUserwordsInText = async function(currentTextId:string, targetLanguageId: string) {
   const user = JSON.parse(localStorage.user);
   const { token } = user;
 
-  const request = await axios.get(`${baseUrl}text/${currentTextId}/language/${targetLanguageId}/`, {
+  const request = await axios.get(`${baseUrl}/text/${currentTextId}/language/${targetLanguageId}/`, {
     headers: { Authorization: `bearer ${token}` },
   });
 
@@ -20,7 +22,7 @@ const addWordWithTranslation = async function(word: UserWord) {
   const { token } = user;
 
   // backend needs to be changed from word id to word
-  const request = await axios.post(`${baseUrl}`, word, {
+  const request = await axios.post(`${baseUrl}/`, word, {
     headers: { Authorization: `bearer ${token}` },
   });
 
@@ -33,7 +35,7 @@ const updateStatus = async function(word: UserWord) {
   const { token } = user;
   const { id, status } = word;
 
-  const response = await axios.put(`${baseUrl}${id}`, { status }, {
+  const response = await axios.put(`${baseUrl}/${id}`, { status }, {
     headers: { Authorization: `bearer ${token}` },
   });
 


### PR DESCRIPTION
## Description

To prepare for the build process I had to strip the hard-coded `localhost` from the `baseUrl`. It is now added if the React app is run in development mode: If you want the app to access your locally running server, you have to use `npm run dev` on the front end now. 

Also a little cosmetic work on the `baseUrl`s: none of them ends in `/` any more which makes adding to the base URL in the axios call a bit more readable.
