### PR TITLE
set production host to staging app

### DIFF
--- a/src/services/languages.ts
+++ b/src/services/languages.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Language } from '../types';
 
-const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://alexandria-reader-staging.herokuapp.com';
 
 const baseUrl = `${host}/api/languages`;
 

--- a/src/services/login.ts
+++ b/src/services/login.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { LoginDetails } from '../types';
 
-const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://alexandria-reader-staging.herokuapp.com';
 
 const baseUrl = `${host}/api/login`;
 

--- a/src/services/texts.ts
+++ b/src/services/texts.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Text } from '../types';
 
-const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://alexandria-reader-staging.herokuapp.com';
 
 const baseUrl = `${host}/api/texts`;
 

--- a/src/services/translations.ts
+++ b/src/services/translations.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Translation } from '../types';
 
-const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://alexandria-reader-staging.herokuapp.com';
 
 const baseUrl = `${host}/api/translations`;
 

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { CurrentUserLanguages, SanitizedUser, User } from '../types';
 
-const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://alexandria-reader-staging.herokuapp.com';
 
 const baseUrl = `${host}/api/users`;
 

--- a/src/services/words.ts
+++ b/src/services/words.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { UserWord } from '../types';
 
-const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : '';
+const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://alexandria-reader-staging.herokuapp.com';
 
 const baseUrl = `${host}/api/words`;
 


### PR DESCRIPTION
## Description

This connects the React app services to the staging app on Heroku (should be the production app later on) to facilitate split deployment of front end and back end. 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| :heavy_check_mark:     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |
