### PR TITLE
extracted dbHost to env, added netlify config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
       "error",
       { "argsIgnorePattern": "^_" }
     ],
+    "no-console": "off",
     "no-case-declarations": "off",
     "linebreak-style": "warn",
     "@typescript-eslint/func-names": ["off"],

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,17 +1,11 @@
-# Production context: all deploys from the Production branch set in your site’s
-# Branches settings in the UI will inherit these settings.
-[context.production.environment]
-  DB_HOST = "https://alexandria-reader.herokuapp.com"
+[context.production]
+  environment = { DB_HOST = "https://alexandria-reader.herokuapp.com" }
+  command = "echo 'production' && echo $DB_HOST"
 
-# Deploy Preview context: all deploys generated from a pull/merge request will
-# inherit these settings.
-[context.deploy-preview.environment]
-  DB_HOST = "https://alexandria-reader-staging.herokuapp.com"
-  command = "echo DB_HOST"
+[context.deploy-preview]
+  environment = { DB_HOST = "https://alexandria-reader-staging.herokuapp.com" }
+  command = "echo 'preview' && echo $DB_HOST"
 
-# Branch Deploy context: all deploys that are not from a pull/merge request or
-# from the Production branch will inherit these settings.
 [context.branch-deploy]
-  command = "echo branch"
-[context.branch-deploy.environment]
-  DB_HOST = "https://alexandria-reader-staging.herokuapp.com"
+  environment = { DB_HOST = "https://alexandria-reader-staging.herokuapp.com" }
+  command = "echo 'branch' && echo $DB_HOST"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,8 @@
 [context.production]
   environment = { DB_HOST = "https://alexandria-reader.herokuapp.com" }
-  command = "echo 'production' && echo $DB_HOST"
 
 [context.deploy-preview]
   environment = { DB_HOST = "https://alexandria-reader-staging.herokuapp.com" }
-  command = "echo 'preview' && echo $DB_HOST"
 
 [context.branch-deploy]
   environment = { DB_HOST = "https://alexandria-reader-staging.herokuapp.com" }
-  command = "echo 'branch' && echo $DB_HOST"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[context.production]
+  environment = { REACT_APP_DB_HOST = "https://alexandria-reader.herokuapp.com" }
+
+[context.deploy-preview]
+  environment = { REACT_APP_DB_HOST = "https://alexandria-reader-staging.herokuapp.com" }
+
+[context.branch-deploy]
+  environment = { REACT_APP_DB_HOST = "https://alexandria-reader-staging.herokuapp.com" }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,16 @@
+# Production context: all deploys from the Production branch set in your site’s
+# Branches settings in the UI will inherit these settings.
+[context.production.environment]
+  DB_HOST = "https://alexandria-reader.herokuapp.com"
+
+# Deploy Preview context: all deploys generated from a pull/merge request will
+# inherit these settings.
+[context.deploy-preview.environment]
+  DB_HOST = "https://alexandria-reader-staging.herokuapp.com"
+
+# Branch Deploy context: all deploys that are not from a pull/merge request or
+# from the Production branch will inherit these settings.
+[context.branch-deploy]
+  command = "echo branch"
+[context.branch-deploy.environment]
+  DB_HOST = "https://alexandria-reader-staging.herokuapp.com"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,7 @@
 # inherit these settings.
 [context.deploy-preview.environment]
   DB_HOST = "https://alexandria-reader-staging.herokuapp.com"
+  command = "echo DB_HOST"
 
 # Branch Deploy context: all deploys that are not from a pull/merge request or
 # from the Production branch will inherit these settings.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,0 @@
-[context.production]
-  environment = { DB_HOST = "https://alexandria-reader.herokuapp.com" }
-
-[context.deploy-preview]
-  environment = { DB_HOST = "https://alexandria-reader-staging.herokuapp.com" }
-
-[context.branch-deploy]
-  environment = { DB_HOST = "https://alexandria-reader-staging.herokuapp.com" }

--- a/src/services/dbHost.ts
+++ b/src/services/dbHost.ts
@@ -1,0 +1,1 @@
+export default process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : process.env.DB_HOST;

--- a/src/services/dbHost.ts
+++ b/src/services/dbHost.ts
@@ -1,1 +1,1 @@
-export default process.env.DB_HOST ? process.env.DB_HOST : 'http://localhost:3000';
+export default process.env.REACT_APP_DB_HOST ? process.env.REAC_APP_DB_HOST : 'http://localhost:3000';

--- a/src/services/dbHost.ts
+++ b/src/services/dbHost.ts
@@ -1,1 +1,1 @@
-export default process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : process.env.DB_HOST;
+export default process.env.DB_HOST ? process.env.DB_HOST : 'http://localhost:3000';

--- a/src/services/languages.ts
+++ b/src/services/languages.ts
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import { Language } from '../types';
+import dbHost from './dbHost';
 
-const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://alexandria-reader-staging.herokuapp.com';
-
-const baseUrl = `${host}/api/languages`;
+const baseUrl = `${dbHost}/api/languages`;
 
 const getAllLanguages = async function() {
   const request = await axios.get(`${baseUrl}/`);

--- a/src/services/login.ts
+++ b/src/services/login.ts
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import { LoginDetails } from '../types';
+import dbHost from './dbHost';
 
-const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://alexandria-reader-staging.herokuapp.com';
-
-const baseUrl = `${host}/api/login`;
+const baseUrl = `${dbHost}/api/login`;
 
 const loginUser = async function(credentials: LoginDetails) {
   const request = await axios.post(baseUrl, credentials);

--- a/src/services/login.ts
+++ b/src/services/login.ts
@@ -2,6 +2,8 @@ import axios from 'axios';
 import { LoginDetails } from '../types';
 import dbHost from './dbHost';
 
+console.log(process.env.DB_HOST);
+
 const baseUrl = `${dbHost}/api/login`;
 
 const loginUser = async function(credentials: LoginDetails) {

--- a/src/services/texts.ts
+++ b/src/services/texts.ts
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import { Text } from '../types';
+import dbHost from './dbHost';
 
-const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://alexandria-reader-staging.herokuapp.com';
-
-const baseUrl = `${host}/api/texts`;
+const baseUrl = `${dbHost}/api/texts`;
 
 const getAllUserTextsByLanguage = async function(languageId: string) {
   const user = JSON.parse(localStorage.user);

--- a/src/services/translations.ts
+++ b/src/services/translations.ts
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import { Translation } from '../types';
+import dbHost from './dbHost';
 
-const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://alexandria-reader-staging.herokuapp.com';
-
-const baseUrl = `${host}/api/translations`;
+const baseUrl = `${dbHost}/api/translations`;
 
 const addTranslation = async function(translationObj: Translation) {
   const user = JSON.parse(localStorage.user);

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import { CurrentUserLanguages, SanitizedUser, User } from '../types';
+import dbHost from './dbHost';
 
-const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://alexandria-reader-staging.herokuapp.com';
-
-const baseUrl = `${host}/api/users`;
+const baseUrl = `${dbHost}/api/users`;
 
 const addUser = async function(newUser: User) {
   const response = await axios.post(`${baseUrl}/`, newUser)

--- a/src/services/words.ts
+++ b/src/services/words.ts
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import { UserWord } from '../types';
+import dbHost from './dbHost';
 
-const host = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://alexandria-reader-staging.herokuapp.com';
-
-const baseUrl = `${host}/api/words`;
+const baseUrl = `${dbHost}/api/words`;
 
 const getUserwordsInText = async function(currentTextId:string, targetLanguageId: string) {
   const user = JSON.parse(localStorage.user);


### PR DESCRIPTION
## Description

* I added a `netlify.toml` to set the database hosts in an environment variable instead of the source code. 
  - Preview apps and branch deploys use the staging database from Heroku staging app.
  - Production app uses database from Heroku production app.
* Extracted code to set `dbHost` to separate module in `services`.
* Turned off `no-console` in `eslintrc` for now. 

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|  :heavy_check_mark:    | :sparkles: New feature     |
|     | :hammer: Refactoring       |
