### PR TITLE
Multiple bug fixes, text selection enhancements

### DIFF
--- a/src/components/texts/Body-Paragraph.tsx
+++ b/src/components/texts/Body-Paragraph.tsx
@@ -2,6 +2,7 @@ import {
   selector, useRecoilState, useRecoilValue, useSetRecoilState,
 } from 'recoil';
 import { useState, useEffect } from 'react';
+// import { textContent } from 'domutils';
 import {
   currentwordContextState, currentwordState, markedwordsState, userwordsState,
 } from '../../states/recoil-states';
@@ -78,9 +79,10 @@ const TextBody = function ({ title, textBody }: { title: string, textBody: strin
     return (element as Element).nodeName !== undefined;
   };
 
-  const removeUnusedWord = function(event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
+  const removeUnusedWordOrGetPhrase = function(
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) {
     const { target }: { target: Element | EventTarget } = event;
-    // event.preventDefault
     // if a user clicks empty space inside the text div, the current word is removed
     // if that word did not have a translation (or id) it is removed from userWords
     if (!window.getSelection()?.toString() && isElement(target) && target.nodeName !== 'SPAN') {
@@ -90,13 +92,24 @@ const TextBody = function ({ title, textBody }: { title: string, textBody: strin
         .filter((wordObj) => wordObj.id !== undefined)];
       setUserWords(updatedWords);
       setCurrentWordContext(null);
+    } else if (isElement(target) && target.nodeName === 'SPAN' && target?.textContent) {
+      const text = target?.textContent?.split(' ').filter(Boolean);
+
+      // if user clicks on a span containing words and a space, it's a phrase
+      if (text.length > 1) {
+        const current = userWords.filter((wordObj) => wordObj.word === target.textContent);
+        if (current.length === 1) {
+          setCurrentWord(current[0]);
+        }
+      }
     }
+
     window.getSelection()?.removeAllRanges();
   };
 
   return (
     <>
-      <div onMouseUp={(event) => removeUnusedWord(event)} className={`container mx-auto p-4 m-4 md:col-span-2 md:col-start-1 bg-white px-4 py-5 shadow sm:rounded-lg sm:px-6 ${currentWord && window.innerWidth < 760 ? 'blur-sm bg-gray-300' : ''}`}>
+      <div onMouseUp={(event) => removeUnusedWordOrGetPhrase(event)} className={`container mx-auto p-4 m-4 md:col-span-2 md:col-start-1 bg-white px-4 py-5 shadow sm:rounded-lg sm:px-6 ${currentWord && window.innerWidth < 760 ? 'blur-sm bg-gray-300' : ''}`}>
         <h1 className='font-bold text-3xl mb-2'>{title}</h1>
           {paragraphs.map((paragraph, index) => <><div className='mb-3'><Paragraph key={index} paragraph={paragraph} /></div></>)}
       </div>

--- a/src/components/texts/Body-Paragraph.tsx
+++ b/src/components/texts/Body-Paragraph.tsx
@@ -97,7 +97,8 @@ const TextBody = function ({ title, textBody }: { title: string, textBody: strin
 
       // if user clicks on a span containing words and a space, it's a phrase
       if (text.length > 1) {
-        const current = userWords.filter((wordObj) => wordObj.word === target.textContent);
+        const current = userWords.filter((wordObj) => wordObj.word === target
+          .textContent?.toLowerCase());
         if (current.length === 1) {
           setCurrentWord(current[0]);
         }

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -87,7 +87,7 @@ export const Word = function ({ word, dataKey, context }:
     const possiblePhraseDiv = input?.parentElement?.parentElement;
 
     // checks if user tapped on an existing phrase, if so, show the phrase instead of the word
-    if (possiblePhraseDiv?.dataset?.type === 'phrase' && possiblePhraseDiv?.textContent) {
+    if (possiblePhraseDiv?.dataset?.type === 'phrase' && possiblePhraseDiv?.textContent && event.type === 'touchend') {
       const current = userWords.filter((wordObj) => wordObj.word === possiblePhraseDiv?.textContent?.toLowerCase());
 
       if (current.length === 1) {

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -85,32 +85,43 @@ export const Word = function ({ word, dataKey, context }:
 
   const getClickedOnWord = function (event: React.MouseEvent | TouchEvent<HTMLSpanElement>) {
     const input = event.target as HTMLElement;
-    const selectedWord = input.textContent || '';
+    const possiblePhraseDiv = input?.parentElement?.parentElement;
 
-    const wordObj = userWords.filter((arrWordObj) => arrWordObj.word.toLowerCase()
-      === selectedWord.toLowerCase());
+    // checks if user tapped on an existing phrase, if so, show the phrase instead of the word
+    if (possiblePhraseDiv?.dataset?.type === 'phrase' && possiblePhraseDiv?.textContent) {
+      const current = userWords.filter((wordObj) => wordObj.word === possiblePhraseDiv?.textContent?.toLowerCase());
 
-    if (wordObj.length > 0) {
-      const wordObject = wordObj[0];
-
-      if (wordObject.status === undefined) {
-        wordObject.status = 'learning';
+      if (current.length === 1) {
+        setCurrentWord(current[0]);
       }
-
-      const updatedWords = [...userWords.filter((arrWordObj) => arrWordObj.word.toLowerCase()
-        !== selectedWord.toLowerCase() && arrWordObj.id), wordObject];
-      setUserWords(updatedWords);
-      setCurrentWord(wordObject);
     } else {
-      const newWordObj: UserWord = {
-        word: `${selectedWord.toLowerCase()}`, status: 'learning', translations: [],
-      };
+      const selectedWord = input.textContent || '';
 
-      setCurrentWord(newWordObj);
+      const wordObj = userWords.filter((arrWordObj) => arrWordObj.word.toLowerCase()
+        === selectedWord.toLowerCase());
 
-      const updatedWords = [...userWords
-        .filter((wordObject) => wordObject.id !== undefined), newWordObj];
-      setUserWords(updatedWords);
+      if (wordObj.length > 0) {
+        const wordObject = { ...wordObj[0] };
+
+        if (wordObject.status === undefined) {
+          wordObject.status = 'learning';
+        }
+
+        const updatedWords = [...userWords.filter((arrWordObj) => arrWordObj.word.toLowerCase()
+          !== selectedWord.toLowerCase() && arrWordObj.id), wordObject];
+        setUserWords(updatedWords);
+        setCurrentWord(wordObject);
+      } else {
+        const newWordObj: UserWord = {
+          word: `${selectedWord.toLowerCase()}`, status: 'learning', translations: [],
+        };
+
+        setCurrentWord(newWordObj);
+
+        const updatedWords = [...userWords
+          .filter((wordObject) => wordObject.id !== undefined), newWordObj];
+        setUserWords(updatedWords);
+      }
     }
   };
 
@@ -128,6 +139,7 @@ export const Word = function ({ word, dataKey, context }:
     <div className='inline-block my-1'>
       <span
         onTouchEnd={(event) => {
+          console.log('touch');
           if (touchStart === window.scrollY) {
             if (window.getSelection()?.toString()) {
               getHighlightedWordOrPhrase(event);
@@ -140,6 +152,8 @@ export const Word = function ({ word, dataKey, context }:
         }}
 
         onMouseUp={(event) => {
+          console.log('click');
+
           if (window.getSelection()?.toString()) {
             getHighlightedWordOrPhrase(event);
           } else {
@@ -151,7 +165,8 @@ export const Word = function ({ word, dataKey, context }:
 
         onTouchStart={() => setTouchStart(window.scrollY)}
         className={`${wordClass} cursor-pointer border border-transparent betterhover:hover:border-blue-500 py-1 p-px rounded-md`}
-        data-key={dataKey}>
+        data-key={dataKey}
+        data-type={'word'}>
         {word}
       </span>
     </div>
@@ -178,7 +193,7 @@ export const Phrase = function ({ phrase, context }: { phrase: string, context: 
   return (
     <div className='inline'>
       {/* <span className={`${wordClass} cursor-pointer border border-transparent betterhover:hover:border-blue-500 -p[1px] py-2 rounded-md`}> */}
-      <span className={`${wordClass} cursor-pointer m-[-1px] border border-transparent betterhover:hover:border-orange-500 hover:py-3 py-2 rounded-md`}>
+      <span className={`${wordClass} cursor-pointer m-[-1px] border border-transparent betterhover:hover:border-orange-500 hover:py-3 py-2 rounded-md`} data-type={'phrase'}>
         {
           parts.map((word, index, array) => <Fragment>
             <Word key={word + index} dataKey={word + index} word={word} context={context} />

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import {
   Fragment, TouchEvent, useState,
 } from 'react';
@@ -149,7 +150,7 @@ export const Word = function ({ word, dataKey, context }:
         }}
 
         onTouchStart={() => setTouchStart(window.scrollY)}
-        className={`${wordClass} cursor-pointer border border-transparent betterhover:hover:border-blue-500 betterhover:hover:border py-1 p-px rounded-md`}
+        className={`${wordClass} cursor-pointer border border-transparent betterhover:hover:border-blue-500 py-1 p-px rounded-md`}
         data-key={dataKey}>
         {word}
       </span>
@@ -176,7 +177,8 @@ export const Phrase = function ({ phrase, context }: { phrase: string, context: 
 
   return (
     <div className='inline'>
-      <span className={`${wordClass} cursor-pointer  py-2 rounded-md`}>
+      {/* <span className={`${wordClass} cursor-pointer border border-transparent betterhover:hover:border-blue-500 -p[1px] py-2 rounded-md`}> */}
+      <span className={`${wordClass} cursor-pointer m-[-1px] border border-transparent betterhover:hover:border-orange-500 hover:py-3 py-2 rounded-md`}>
         {
           parts.map((word, index, array) => <Fragment>
             <Word key={word + index} dataKey={word + index} word={word} context={context} />

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -26,7 +26,6 @@ export const Word = function ({ word, dataKey, context }:
   const getHighlightedWordOrPhrase = function(_event: unknown) {
     // fix bug where if a user selects backwards, first and last words are swapped
     const selection = window.getSelection();
-    // console.log('getting selection');
 
     if (selection?.toString() && selection !== null) {
       const selectedString = selection.toString();
@@ -139,7 +138,6 @@ export const Word = function ({ word, dataKey, context }:
     <div className='inline-block my-1'>
       <span
         onTouchEnd={(event) => {
-          console.log('touch');
           if (touchStart === window.scrollY) {
             if (window.getSelection()?.toString()) {
               getHighlightedWordOrPhrase(event);
@@ -152,8 +150,6 @@ export const Word = function ({ word, dataKey, context }:
         }}
 
         onMouseUp={(event) => {
-          console.log('click');
-
           if (window.getSelection()?.toString()) {
             getHighlightedWordOrPhrase(event);
           } else {

--- a/src/components/texts/SingleText.tsx
+++ b/src/components/texts/SingleText.tsx
@@ -11,6 +11,7 @@ import {
   currentwordState,
   userState,
 } from '../../states/recoil-states';
+import getToken from '../../utils/getToken';
 
 const SingleText = function () {
   const [currentText, setCurrentText] = useRecoilState(currenttextState);
@@ -29,7 +30,7 @@ const SingleText = function () {
   };
 
   const getTextById = async function() {
-    if (params.textId && user) {
+    if (params.textId && getToken()) {
       const text = await textsService.getTextById(params.textId);
       setCurrentText(text);
     }


### PR DESCRIPTION
## Description

Fixed bug where existing phrases couldnt be selected.
Added border and highlighting to phrases.
Clicking on an existing phrase on mobile defaults to selecting the phrase.
Fixed a bug where going directly to a text didn't work (e.g. `texts/:id`).

## Related Issue

closes #113 

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  X | :bug: Bug fix              |
|     | :sparkles: New feature     |
|  X | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->


### After

<!-- If UI feature, take provide screenshots -->


## Testing Steps / QA Criteria

<!-- Provide steps reviewers need to follow to properly test your additions. -->
