### PR TITLE
Big changes on the single view page, now it looks good on all devices, including iPad

### DIFF
--- a/src/components/texts/Body-Paragraph.tsx
+++ b/src/components/texts/Body-Paragraph.tsx
@@ -110,7 +110,7 @@ const TextBody = function ({ title, textBody }: { title: string, textBody: strin
 
   return (
     <>
-      <div onMouseUp={(event) => removeUnusedWordOrGetPhrase(event)} className={`container mx-auto p-4 m-4 md:col-span-2 md:col-start-1 bg-white px-4 py-5 shadow sm:rounded-lg sm:px-6 ${currentWord && window.innerWidth < 760 ? 'blur-sm bg-gray-300' : ''}`}>
+      <div onMouseUp={(event) => removeUnusedWordOrGetPhrase(event)} className={`container mx-auto p-4 md:col-span-1 md:col-start-1 bg-white px-4 py-5 shadow sm:rounded-lg sm:px-6 ${currentWord && window.innerWidth < 760 ? 'blur-sm bg-gray-300' : ''}`}>
         <h1 className='font-bold text-3xl mb-2'>{title}</h1>
           {paragraphs.map((paragraph, index) => <><div className='mb-3'><Paragraph key={index} paragraph={paragraph} /></div></>)}
       </div>

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -87,7 +87,7 @@ export const Word = function ({ word, dataKey, context }:
     const possiblePhraseDiv = input?.parentElement?.parentElement;
 
     // checks if user tapped on an existing phrase, if so, show the phrase instead of the word
-    if (possiblePhraseDiv?.dataset?.type === 'phrase' && possiblePhraseDiv?.textContent && event.type === 'touchend') {
+    if (possiblePhraseDiv?.dataset?.type === 'phrase' && possiblePhraseDiv?.textContent) {
       const current = userWords.filter((wordObj) => wordObj.word === possiblePhraseDiv?.textContent?.toLowerCase());
 
       if (current.length === 1) {
@@ -150,9 +150,11 @@ export const Word = function ({ word, dataKey, context }:
         }}
 
         onMouseUp={(event) => {
-          if (window.getSelection()?.toString()) {
+          const pointerEvent = event.nativeEvent as PointerEvent | TouchEvent;
+
+          if (window.getSelection()?.toString() && pointerEvent.type === 'mouseup') {
             getHighlightedWordOrPhrase(event);
-          } else {
+          } else if (pointerEvent.type === 'mouseup') {
             getClickedOnWord(event);
           }
           window.getSelection()?.removeAllRanges();

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -110,12 +110,14 @@ export const Word = function ({ word, dataKey, context }:
           !== selectedWord.toLowerCase() && arrWordObj.id), wordObject];
         setUserWords(updatedWords);
         setCurrentWord(wordObject);
+        setCurrentWordContext(context);
       } else {
         const newWordObj: UserWord = {
           word: `${selectedWord.toLowerCase()}`, status: 'learning', translations: [],
         };
 
         setCurrentWord(newWordObj);
+        setCurrentWordContext(context);
 
         const updatedWords = [...userWords
           .filter((wordObject) => wordObject.id !== undefined), newWordObj];

--- a/src/components/texts/SingleText.tsx
+++ b/src/components/texts/SingleText.tsx
@@ -47,8 +47,8 @@ const SingleText = function () {
   if (currentText) {
     return (
       <div className='bg-gray-100'>
-        <div className='grid grid-cols-1 md:grid-cols-3 md:gap-4 md:my-4'>
-        {/* <div className='grid grid-cols-1 md:grid-cols-[1fr, 1fr, 350px] md:gap-4 my-4'> */}
+        {/* <div className='grid grid-cols-1 md:grid-cols-3 md:gap-4 md:my-4'> */}
+        <div className='grid grid-cols-1 md:grid-cols-[1fr, 400px] md:gap-8 my-8 lg:max-w-7xl lg:grid-flow-col-dense'>
         {/* Check if title ends with a dot, if not add one */}
           <TextBody title={currentText.title} textBody={`${currentText.title}. \n${currentText.body}`} />
           <TranslationInput word={currentWord}/>

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -102,7 +102,7 @@ const TranslationComponent = function({ word }: { word: UserWord | null }) {
           const newTranslationObj: Translation = {
             translation,
             targetLanguageId: user.knownLanguageId,
-            context: '',
+            context: currentWordContext || '',
             wordId: newUserWord.id,
           };
 

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -50,11 +50,11 @@ const ChangeStatus = function({ word }: { word: UserWord | null }) {
 
 const DictionaryIframe = function({ url }: { url: string }) {
   return (
-    <>
-      <iframe width="320" height="350"
+    <div className=''>
+      <iframe title='Wordreference dictionary' className='' width="320" height="350"
         src={url}>
       </iframe>
-    </>
+    </div>
   );
 };
 
@@ -227,7 +227,7 @@ const TranslationInput = function({ word }: { word: UserWord | null }) {
   if (window.innerWidth > 768) {
     return (
       <>
-        <div className='bg-white shadow sm:rounded-lg sm:px-6 py-4 md:flex flex-col m-4 md:col-start-3 min-w-min md:col-span-1 hidden'>
+        <div className='bg-white shadow sm:rounded-lg sm:px-6 py-4 md:flex flex-col md:col-start-2 w-[368px] md:col-span-1 hidden'>
           {word && <div className='flex flex-row items-center'>
             <svg onClick={() => speak()} xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />

--- a/src/index.css
+++ b/src/index.css
@@ -60,3 +60,17 @@ code {
 /* ::slection {
   appearance: none;
 } */
+
+/* iframe {
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch; */
+/* } */
+
+/* iframe html {
+  -webkit-transform:translate3d(0,0,0);
+  overflow-x: hidden;
+}
+
+iframe > html {
+  width: 300px;
+} */


### PR DESCRIPTION
## Description

The translation input component is now a fixed size, meaning the page doesn't jump around when a user taps on a word or opens the dictionary.
The translation component no longer goes over the edge of the page, and the spacing is consistent.
Fixed bug where touches were detected as clicks on iPad safari.


## Related Issue

closes #117 

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  X | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |
