### PR TITLE
Added sticky positioning to the translation input element and numerous bug fixes related to texts

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -202,7 +202,7 @@ export default function Navbar() {
                     leaveFrom="transform opacity-100 scale-100"
                     leaveTo="transform opacity-0 scale-95"
                   >
-                    <Menu.Items className="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
+                    <Menu.Items className="origin-top-right z-10 absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
                       <Menu.Item>
                         {({ active }) => (
                           <a

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -137,7 +137,7 @@ export const Word = function ({ word, dataKey, context }:
   }
 
   return (
-    <div className='inline-block my-1'>
+    <div className='inline-block my-1.5'>
       <span
         onTouchEnd={(event) => {
           if (touchStart === window.scrollY) {
@@ -193,7 +193,7 @@ export const Phrase = function ({ phrase, context }: { phrase: string, context: 
   return (
     <div className='inline'>
       {/* <span className={`${wordClass} cursor-pointer border border-transparent betterhover:hover:border-blue-500 -p[1px] py-2 rounded-md`}> */}
-      <span className={`${wordClass} cursor-pointer m-[-1px] border border-transparent betterhover:hover:border-orange-500 hover:py-3 py-2 rounded-md`} data-type={'phrase'}>
+      <span className={`${wordClass} cursor-pointer m-[-1px] border border-transparent betterhover:hover:border-zinc-500 hover:py-2.5 py-1.5 rounded-md`} data-type={'phrase'}>
         {
           parts.map((word, index, array) => <Fragment>
             <Word key={word + index} dataKey={word + index} word={word} context={context} />

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -129,11 +129,11 @@ export const Word = function ({ word, dataKey, context }:
   let wordClass = '';
 
   if (wordStatus === 'learning') {
-    wordClass = 'bg-amber-500';
+    wordClass = 'bg-orange-400';
   } else if (wordStatus === 'familiar') {
-    wordClass = 'bg-yellow-500';
+    wordClass = 'bg-yellow-300';
   } else if (wordStatus === 'learned') {
-    wordClass = 'bg-gray-200';
+    wordClass = 'bg-green-200';
   }
 
   return (
@@ -181,11 +181,11 @@ export const Phrase = function ({ phrase, context }: { phrase: string, context: 
   let wordClass = '';
 
   if (phraseStatus === 'learning') {
-    wordClass = 'bg-amber-500';
+    wordClass = 'bg-orange-300';
   } else if (phraseStatus === 'familiar') {
-    wordClass = 'bg-yellow-500';
+    wordClass = 'bg-yellow-300';
   } else if (phraseStatus === 'learned') {
-    wordClass = 'bg-gray-200';
+    wordClass = 'bg-green-200';
   }
 
   const parts = phrase.split(' ');

--- a/src/components/texts/SingleText.tsx
+++ b/src/components/texts/SingleText.tsx
@@ -46,9 +46,9 @@ const SingleText = function () {
 
   if (currentText) {
     return (
-      <div className='bg-gray-100'>
+      <div className='bg-gray-100 mx-auto max-w-7xl lg:px-8'>
         {/* <div className='grid grid-cols-1 md:grid-cols-3 md:gap-4 md:my-4'> */}
-        <div className='grid grid-cols-1 md:grid-cols-[1fr, 400px] md:gap-8 my-8 lg:max-w-7xl lg:grid-flow-col-dense'>
+        <div className='grid grid-cols-1 md:grid-cols-[1fr, 400px] md:gap-8 my-8 lg:grid-flow-col-dense'>
         {/* Check if title ends with a dot, if not add one */}
           <TextBody title={currentText.title} textBody={`${currentText.title}. \n${currentText.body}`} />
           <TranslationInput word={currentWord}/>

--- a/src/components/texts/SingleText.tsx
+++ b/src/components/texts/SingleText.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { useRecoilState, useSetRecoilState, useRecoilValue } from 'recoil';
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
@@ -37,10 +38,11 @@ const SingleText = function () {
   };
 
   useEffect(() => {
-    if (currentText && currentText.id === params.textId) {
+    if (currentText) {
       fetchUserwords();
     } else {
       getTextById();
+      fetchUserwords();
     }
   }, [currentText]);
 

--- a/src/components/texts/SingleText.tsx
+++ b/src/components/texts/SingleText.tsx
@@ -19,7 +19,6 @@ const SingleText = function () {
   const [currentWord] = useRecoilState(currentwordState);
   const setUserWords = useSetRecoilState(userwordsState);
   const user = useRecoilValue(userState);
-
   const params = useParams();
 
   const fetchUserwords = async function() {
@@ -44,7 +43,7 @@ const SingleText = function () {
       getTextById();
       fetchUserwords();
     }
-  }, [currentText]);
+  }, [currentText, user]);
 
   if (currentText) {
     return (

--- a/src/components/texts/SingleText.tsx
+++ b/src/components/texts/SingleText.tsx
@@ -45,7 +45,7 @@ const SingleText = function () {
     }
   }, [currentText, user]);
 
-  if (currentText) {
+  if (currentText && Number(currentText?.id) === Number(params.textId)) {
     return (
       <div className='bg-gray-100 mx-auto max-w-7xl lg:px-8'>
         {/* <div className='grid grid-cols-1 md:grid-cols-3 md:gap-4 md:my-4'> */}

--- a/src/components/texts/SingleText.tsx
+++ b/src/components/texts/SingleText.tsx
@@ -37,7 +37,7 @@ const SingleText = function () {
   };
 
   useEffect(() => {
-    if (currentText) {
+    if (currentText && currentText.id === params.textId) {
       fetchUserwords();
     } else {
       getTextById();

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable max-len */
-import { ChangeEvent, MouseEvent, useState } from 'react';
+import {
+  ChangeEvent, MouseEvent, useEffect, useState,
+} from 'react';
 
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import {
@@ -138,6 +140,12 @@ const TranslationComponent = function({ word }: { word: UserWord | null }) {
     setTranslation(event.target.value);
     // console.log(event.target.value);
   };
+
+  useEffect(() => {
+    if (showDictionary) {
+      setShowDictionary(false);
+    }
+  }, [currentWord]);
 
   return (
     <div>

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -35,10 +35,10 @@ const ChangeStatus = function({ word }: { word: UserWord | null }) {
 
   const wordStatusToolbar = word
     ? <div className="flex flex-row justify-center overflow-visible">
-        <button className='bg-sky-500 hover:bg-sky-700 text-white font-bold py-2 px-3 rounded my-4' onClick={() => setWordStatus('learning', word)} type={'button'}>Learning</button>
+        <button className='bg-orange-500 hover:bg-orange-700 text-white font-bold py-2 px-3 rounded my-4' onClick={() => setWordStatus('learning', word)} type={'button'}>Learning</button>
         <button className='bg-yellow-500 hover:bg-yellow-700 text-white font-bold py-2 px-3 rounded my-4' onClick={() => setWordStatus('familiar', word)} type={'button'}>Familiar</button>
         <button className='bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-3 rounded my-4' onClick={() => setWordStatus('learned', word)} type={'button'}>Learned</button>
-        <button className='bg-orange-500 hover:bg-orange-700 text-white font-bold py-2 px-3 rounded my-4' onClick={() => setWordStatus(undefined, word)} type={'button'}>Ignore</button>
+        <button className='bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-3 rounded my-4' onClick={() => setWordStatus(undefined, word)} type={'button'}>Ignore</button>
       </div>
     : '';
 

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -227,16 +227,17 @@ const TranslationInput = function({ word }: { word: UserWord | null }) {
   if (window.innerWidth > 768) {
     return (
       <>
-        <div className='bg-white shadow sm:rounded-lg sm:px-6 py-4 md:flex flex-col md:col-start-2 w-[368px] md:col-span-1 hidden'>
-          {word && <div className='flex flex-row items-center'>
-            <svg onClick={() => speak()} xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
-            </svg>
-            <h2 className=' ml-2 text-3xl font-medium text-gray-900 mb-2'>{word.word}</h2>
-          </div>}
-          {!word && <h2 className='ml-2 text-3xl font-medium text-gray-900 my-4'>Select a word</h2>
-}
-          <TranslationComponent word={word} />
+        <div className=' md:col-start-2 md:flex flex-col w-[368px] md:col-span-1 hidden'>
+          <div className='sticky top-10 bg-white shadow sm:rounded-lg sm:px-6 py-4 '>
+            {word && <div className='flex flex-row items-center'>
+              <svg onClick={() => speak()} xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
+              </svg>
+              <h2 className=' ml-2 text-3xl font-medium text-gray-900 mb-2'>{word.word}</h2>
+            </div>}
+            {!word && <h2 className='ml-2 text-3xl font-medium text-gray-900 my-4'>Select a word</h2>}
+            <TranslationComponent word={word} />
+          </div>
         </div>
       </>
     );

--- a/src/components/texts/UserTexts.tsx
+++ b/src/components/texts/UserTexts.tsx
@@ -1,14 +1,82 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable max-len */
-import { useState, useEffect, FormEvent } from 'react';
+import {
+  useState, useEffect, FormEvent, Fragment,
+} from 'react';
 import { Link, Outlet } from 'react-router-dom';
 
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { Menu, Transition } from '@headlessui/react';
 import {
   textlistState, currenttextState, userState, currentwordState,
 } from '../../states/recoil-states';
 
 import textsService from '../../services/texts';
 import { Text } from '../../types';
+import logOut from '../../utils/logOut';
+
+const TextEditDropdown = function() {
+  const openOptionsMenu = function () {
+
+  };
+
+  return (
+    <>
+      <Menu as="div" className="flex m-3 w-5">
+                  <div>
+                    <Menu.Button className="flex text-sm rounded-full">
+                      <span className="sr-only">Open user menu</span>
+                      <svg onClick={() => openOptionsMenu()} xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                      </svg>
+                    </Menu.Button>
+                  </div>
+                  <Transition
+                    as={Fragment}
+                    enter="transition ease-out duration-100"
+                    enterFrom="transform opacity-0 scale-95"
+                    enterTo="transform opacity-100 scale-100"
+                    leave="transition ease-in duration-75"
+                    leaveFrom="transform opacity-100 scale-100"
+                    leaveTo="transform opacity-0 scale-95"
+                  >
+                    <Menu.Items className="origin-top-right z-10 absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
+                      <Menu.Item>
+                        {({ active }) => (
+                          <a
+                            href=""
+                            className={ `block px-4 py-2 text-sm text-gray-700 ${active ? 'bg-gray-100' : ''}` }
+                          >
+                            <div className='flex flex-row justify-between m-2'>
+                              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                              </svg>
+                              Edit
+                            </div>
+                          </a>
+                        )}
+                      </Menu.Item>
+                      <Menu.Item>
+                        {({ active }) => (
+                          <a
+                            href=""
+                            className={`block px-4 py-2 text-sm text-gray-700 ${active ? 'bg-gray-100' : ''}`}
+                          >
+                            <div className='flex flex-row justify-between m-2' onClick={() => alert('Are you sure you want to delete this text? (Deletion not ready)')}>
+                              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                              </svg>
+                              Delete
+                            </div>
+                          </a>
+                        )}
+                      </Menu.Item>
+                    </Menu.Items>
+                  </Transition>
+                </Menu>
+    </>
+  );
+};
 
 const IndividualText = function({ text }: { text: Text }) {
   const setCurrentText = useSetRecoilState(currenttextState);
@@ -24,10 +92,6 @@ const IndividualText = function({ text }: { text: Text }) {
       setTextList(updatedTextList);
       await textsService.removeTextFromServer(id);
     }
-  };
-
-  const openOptionsMenu = function () {
-
   };
 
   useEffect(() => {
@@ -55,14 +119,14 @@ const IndividualText = function({ text }: { text: Text }) {
           </div>
         </Link>
         {/* <div> */}
-          <div className='flex m-3 w-5'>
-            <svg onClick={() => openOptionsMenu()} xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          {/* <div className='flex m-3 w-5'> */}
+            {/* <svg onClick={() => openOptionsMenu()} xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
+            </svg> */}
+            <TextEditDropdown />
           {/* </div> */}
-        </div>
+        {/* </div> */}
       </div>
-
       {/* <button className='bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded' onClick={() => removeTextFromServer(text.id)}>Delete</button> */}
     </li>
   );

--- a/src/components/texts/UserTexts.tsx
+++ b/src/components/texts/UserTexts.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable max-len */
 import {
   useState, useEffect, FormEvent, Fragment,
@@ -13,70 +12,6 @@ import {
 
 import textsService from '../../services/texts';
 import { Text } from '../../types';
-import logOut from '../../utils/logOut';
-
-const TextEditDropdown = function() {
-  const openOptionsMenu = function () {
-
-  };
-
-  return (
-    <>
-      <Menu as="div" className="flex m-3 w-5">
-                  <div>
-                    <Menu.Button className="flex text-sm rounded-full">
-                      <span className="sr-only">Open user menu</span>
-                      <svg onClick={() => openOptionsMenu()} xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                      </svg>
-                    </Menu.Button>
-                  </div>
-                  <Transition
-                    as={Fragment}
-                    enter="transition ease-out duration-100"
-                    enterFrom="transform opacity-0 scale-95"
-                    enterTo="transform opacity-100 scale-100"
-                    leave="transition ease-in duration-75"
-                    leaveFrom="transform opacity-100 scale-100"
-                    leaveTo="transform opacity-0 scale-95"
-                  >
-                    <Menu.Items className="origin-top-right z-10 absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
-                      <Menu.Item>
-                        {({ active }) => (
-                          <a
-                            href=""
-                            className={ `block px-4 py-2 text-sm text-gray-700 ${active ? 'bg-gray-100' : ''}` }
-                          >
-                            <div className='flex flex-row justify-between m-2'>
-                              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                              </svg>
-                              Edit
-                            </div>
-                          </a>
-                        )}
-                      </Menu.Item>
-                      <Menu.Item>
-                        {({ active }) => (
-                          <a
-                            href=""
-                            className={`block px-4 py-2 text-sm text-gray-700 ${active ? 'bg-gray-100' : ''}`}
-                          >
-                            <div className='flex flex-row justify-between m-2'>
-                              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                              </svg>
-                              Delete
-                            </div>
-                          </a>
-                        )}
-                      </Menu.Item>
-                    </Menu.Items>
-                  </Transition>
-                </Menu>
-    </>
-  );
-};
 
 const IndividualText = function({ text }: { text: Text }) {
   const setCurrentText = useSetRecoilState(currenttextState);
@@ -85,8 +20,8 @@ const IndividualText = function({ text }: { text: Text }) {
 
   const user = useRecoilValue(userState);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const removeTextFromServer = async function (id: number | undefined) {
+  const removeTextFromServer = async function () {
+    const { id } = text;
     if (id && user) {
       const updatedTextList = textList.filter((textObj) => textObj.id !== id);
       setTextList(updatedTextList);
@@ -118,16 +53,59 @@ const IndividualText = function({ text }: { text: Text }) {
             </div>
           </div>
         </Link>
-        {/* <div> */}
-          {/* <div className='flex m-3 w-5'> */}
-            {/* <svg onClick={() => openOptionsMenu()} xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg> */}
-            <TextEditDropdown />
-          {/* </div> */}
-        {/* </div> */}
+        <Menu as="div" className="flex m-3 w-5">
+          <div>
+            <Menu.Button className="flex text-sm rounded-full">
+              <span className="sr-only">Open user menu</span>
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </Menu.Button>
+          </div>
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-100"
+            enterFrom="transform opacity-0 scale-95"
+            enterTo="transform opacity-100 scale-100"
+            leave="transition ease-in duration-75"
+            leaveFrom="transform opacity-100 scale-100"
+            leaveTo="transform opacity-0 scale-95"
+          >
+            <Menu.Items className="origin-top-right z-10 absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
+              <Menu.Item>
+                {({ active }) => (
+                  <a
+                    href=""
+                    className={ `block px-4 py-2 text-sm text-gray-700 ${active ? 'bg-gray-100' : ''}` }
+                  >
+                    <div className='flex flex-row justify-between m-2'>
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                      </svg>
+                      Edit
+                    </div>
+                  </a>
+                )}
+              </Menu.Item>
+              <Menu.Item>
+                {({ active }) => (
+                  <a
+                    onClick={() => removeTextFromServer()}
+                    className={`block px-4 py-2 text-sm text-gray-700 ${active ? 'bg-gray-100' : ''}`}
+                  >
+                    <div className='flex flex-row justify-between m-2'>
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      </svg>
+                      Delete
+                    </div>
+                  </a>
+                )}
+              </Menu.Item>
+            </Menu.Items>
+          </Transition>
+        </Menu>
       </div>
-      {/* <button className='bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded' onClick={() => removeTextFromServer(text.id)}>Delete</button> */}
     </li>
   );
 };

--- a/src/components/texts/UserTexts.tsx
+++ b/src/components/texts/UserTexts.tsx
@@ -57,15 +57,70 @@ const NewTextForm = function({
   setShowNewTextForm: Function
 }) {
   return (
-    <div className='flex flex-col'>
-      <p>Add a new text here:</p>
-      <form className='flex flex-col items-center' onSubmit={(event) => submitText(event)}>
-      <input type={'text'} placeholder='title' name='title' value={newTextTitle} onChange={(e) => setNewTextTitle(e.target.value)}></input>
-      <textarea name='text' placeholder='text body' value={newText} onChange={(e) => setNewText(e.target.value)}></textarea>
-      <button className='bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded' type='submit'>Submit</button>
-      <button className='bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded' onClick={() => setShowNewTextForm(false)}>Cancel</button>
-      </form>
-    </div>
+    // <><div className='flex flex-col'>
+    //   <p>Add a new text here:</p>
+    //   <form className='flex flex-col items-center' onSubmit={(event) => submitText(event)}>
+    //     <input type={'text'} placeholder='title' name='title' value={newTextTitle} onChange={(e) => setNewTextTitle(e.target.value)}></input>
+    //     <textarea name='text' placeholder='text body' value={newText} onChange={(e) => setNewText(e.target.value)}></textarea>
+    //     <button className='bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded' type='submit'>Submit</button>
+    //     <button className='bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded' onClick={() => setShowNewTextForm(false)}>Cancel</button>
+    //   </form>
+    // </div>
+    <>
+        <div className="min-h-full flex items-center justify-center py-12 px-6 sm:px-8 lg:px-10">
+          <div className="max-w-sm w-fit space-y-8">
+            <div>
+              <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">Add a new text here:</h2>
+            </div>
+            <form className="mt-8 space-y-6" onSubmit={(event) => submitText(event)}>
+              <div className="rounded-md shadow-sm -space-y-px">
+                <div>
+                  <label htmlFor="title" className="sr-only">
+                    Title
+                  </label>
+                  <input
+                    type='text'
+                    placeholder='title'
+                    name='title'
+                    required
+                    className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                    value={newTextTitle}
+                    onChange={(e) => setNewTextTitle(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="text" className="sr-only">
+                    Password
+                  </label>
+                  <textarea
+                    name='text'
+                    placeholder='text body'
+                    value={newText}
+                    required
+                    className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
+                    onChange={(e) => setNewText(e.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <button
+                  type="submit"
+                  className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                >
+                  Submit
+                </button>
+                <button
+                  className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+                  onClick={() => setShowNewTextForm(false)}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </>
   );
 };
 

--- a/src/components/texts/UserTexts.tsx
+++ b/src/components/texts/UserTexts.tsx
@@ -26,6 +26,10 @@ const IndividualText = function({ text }: { text: Text }) {
     }
   };
 
+  const openOptionsMenu = function () {
+
+  };
+
   useEffect(() => {
     if (currentWord) {
       setCurrentWord(null);
@@ -33,22 +37,32 @@ const IndividualText = function({ text }: { text: Text }) {
   }, []);
 
   return (
-    <li className='mb-2 col-span-3 bg-white rounded-lg shadow relative group divide-y divide-gray-200 sm:mr-5' >
-      <Link key={text.id + text.body.slice(0, 7)} to={`/texts/${text.id}`}>
-        <div onClick={(_event) => setCurrentText(text)} className='w-full flex items-center justify-between p-6 space-x-6 group-hover:shadow-md'>
-          <div className='flex justify-center items-center p-4 rounded-full flex-shrink-0 bg-blue-500'>
-          <svg className="w-7 h-7 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
-          </svg>
-          </div>
-          <div className='flex-1 truncate'>
-            <div className="flex items-center space-x-3">
-              <h2 className='text-gray-900 text-xl font-medium truncate'>{text.title}</h2>
+    <li className='mb-2 col-span-3 bg-white rounded-lg shadow relative group divide-y divide-gray-200' >
+      <div className='flex flex-row justify-between group-hover:shadow-md'>
+        <Link className='w-full' key={text.id + text.body.slice(0, 7)} to={`/texts/${text.id}`}>
+          <div onClick={(_event) => setCurrentText(text)} className='flex items-center p-6 space-x-6'>
+            <div className='flex justify-center items-center p-4 rounded-full flex-shrink-0 bg-blue-500'>
+            <svg className="w-7 h-7 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+            </svg>
             </div>
-            <p className='mt-1 text-gray-500 text-sm truncate'>{`${text.body.slice(0, 97)}...`}</p>
+            <div className='flex-1 truncate'>
+              <div className="flex items-center space-x-3">
+                <h2 className='text-gray-900 text-xl font-medium truncate'>{text.title}</h2>
+              </div>
+              <p className='mt-1 text-gray-500 text-sm truncate'>{`${text.body.slice(0, 97)}...`}</p>
+            </div>
           </div>
+        </Link>
+        {/* <div> */}
+          <div className='flex m-3 w-5'>
+            <svg onClick={() => openOptionsMenu()} xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          {/* </div> */}
         </div>
-      </Link>
+      </div>
+
       {/* <button className='bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded' onClick={() => removeTextFromServer(text.id)}>Delete</button> */}
     </li>
   );

--- a/src/components/texts/UserTexts.tsx
+++ b/src/components/texts/UserTexts.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable max-len */
 import { useState, useEffect, FormEvent } from 'react';
 import { Link, Outlet } from 'react-router-dom';
@@ -15,6 +14,7 @@ const IndividualText = function({ text }: { text: Text }) {
 
   const user = useRecoilValue(userState);
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const removeTextFromServer = async function (id: number | undefined) {
     if (id && user) {
       const updatedTextList = textList.filter((textObj) => textObj.id !== id);
@@ -26,7 +26,7 @@ const IndividualText = function({ text }: { text: Text }) {
   return (
     <li className='mb-2 col-span-3 bg-white rounded-lg shadow relative group divide-y divide-gray-200 sm:mr-5' >
       <Link key={text.id + text.body.slice(0, 7)} to={`/texts/${text.id}`}>
-        <div className='w-full flex items-center justify-between p-6 space-x-6 group-hover:shadow-md'>
+        <div onClick={(_event) => setCurrentText(text)} className='w-full flex items-center justify-between p-6 space-x-6 group-hover:shadow-md'>
           <div className='flex justify-center items-center p-4 rounded-full flex-shrink-0 bg-blue-500'>
           <svg className="w-7 h-7 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
@@ -34,7 +34,7 @@ const IndividualText = function({ text }: { text: Text }) {
           </div>
           <div className='flex-1 truncate'>
             <div className="flex items-center space-x-3">
-              <h2 className='text-gray-900 text-xl font-medium truncate' onClick={(_event) => setCurrentText(text)}>{text.title}</h2>
+              <h2 className='text-gray-900 text-xl font-medium truncate'>{text.title}</h2>
             </div>
             <p className='mt-1 text-gray-500 text-sm truncate'>{`${text.body.slice(0, 97)}...`}</p>
           </div>
@@ -57,15 +57,6 @@ const NewTextForm = function({
   setShowNewTextForm: Function
 }) {
   return (
-    // <><div className='flex flex-col'>
-    //   <p>Add a new text here:</p>
-    //   <form className='flex flex-col items-center' onSubmit={(event) => submitText(event)}>
-    //     <input type={'text'} placeholder='title' name='title' value={newTextTitle} onChange={(e) => setNewTextTitle(e.target.value)}></input>
-    //     <textarea name='text' placeholder='text body' value={newText} onChange={(e) => setNewText(e.target.value)}></textarea>
-    //     <button className='bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded' type='submit'>Submit</button>
-    //     <button className='bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded' onClick={() => setShowNewTextForm(false)}>Cancel</button>
-    //   </form>
-    // </div>
     <>
         <div className="min-h-full flex items-center justify-center py-12 px-6 sm:px-8 lg:px-10">
           <div className="max-w-sm w-fit space-y-8">
@@ -161,6 +152,7 @@ const UserTexts = function() {
     setNewTextTitle('');
     setShowNewTextForm(false);
   };
+  console.log(textList);
 
   return (
       <div className='max-w-7xl mx-auto px-4 pt-8 sm:px-6 lg:px-8'>

--- a/src/components/texts/UserTexts.tsx
+++ b/src/components/texts/UserTexts.tsx
@@ -161,7 +161,6 @@ const UserTexts = function() {
     setNewTextTitle('');
     setShowNewTextForm(false);
   };
-  console.log(textList);
 
   return (
       <div className='max-w-7xl mx-auto px-4 pt-8 sm:px-6 lg:px-8'>

--- a/src/components/texts/UserTexts.tsx
+++ b/src/components/texts/UserTexts.tsx
@@ -62,7 +62,7 @@ const TextEditDropdown = function() {
                             href=""
                             className={`block px-4 py-2 text-sm text-gray-700 ${active ? 'bg-gray-100' : ''}`}
                           >
-                            <div className='flex flex-row justify-between m-2' onClick={() => alert('Are you sure you want to delete this text? (Deletion not ready)')}>
+                            <div className='flex flex-row justify-between m-2'>
                               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                               </svg>

--- a/src/components/texts/UserTexts.tsx
+++ b/src/components/texts/UserTexts.tsx
@@ -3,7 +3,9 @@ import { useState, useEffect, FormEvent } from 'react';
 import { Link, Outlet } from 'react-router-dom';
 
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { textlistState, currenttextState, userState } from '../../states/recoil-states';
+import {
+  textlistState, currenttextState, userState, currentwordState,
+} from '../../states/recoil-states';
 
 import textsService from '../../services/texts';
 import { Text } from '../../types';
@@ -11,6 +13,7 @@ import { Text } from '../../types';
 const IndividualText = function({ text }: { text: Text }) {
   const setCurrentText = useSetRecoilState(currenttextState);
   const [textList, setTextList] = useRecoilState(textlistState);
+  const [currentWord, setCurrentWord] = useRecoilState(currentwordState);
 
   const user = useRecoilValue(userState);
 
@@ -22,6 +25,12 @@ const IndividualText = function({ text }: { text: Text }) {
       await textsService.removeTextFromServer(id);
     }
   };
+
+  useEffect(() => {
+    if (currentWord) {
+      setCurrentWord(null);
+    }
+  }, []);
 
   return (
     <li className='mb-2 col-span-3 bg-white rounded-lg shadow relative group divide-y divide-gray-200 sm:mr-5' >


### PR DESCRIPTION
Added sticky positioning to the translation input element on long texts.
Fixed a bug where the dictionary iframe didn't close if a user clicked on another word or phrase.
Fixed a bug where closing a text and clicking on another would still open the original text.
Fixed a bug where text wasn't centred when reading a text. Added more consistent spacing on the single text page..
Fixed a bug where setting menu was hidden behind translation div.
Tweaked the word coloring (to be confirmed?).
Tweaked word spacing in a text so highlights don't overlap.
Fixed a bug where current word was not reset when closing a text.
Fixed a bug where sometimes user words were not loaded.
Fixed a bug where user could see previous text briefly when opening a new text. Will add placeholder later.
Added dropdown menu on user text items with edit and delete button (functionality of edit button not yet implemented).
Added delete functionality to dropdown menu.

|     | Type                       |
| --- | -------------------------- |
|  X | :bug: Bug fix              |
|  X | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

closes #125 
closes #128 
closes #129 
closes #126 
closes #119 
closes #130 

Open a very long text, then click a word and scroll down