### PR TITLE
mh fixes 123

### DIFF
--- a/src/components/Words.tsx
+++ b/src/components/Words.tsx
@@ -95,7 +95,7 @@ const WordTable = function () {
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                         {userword.translations.map((translation) => (
-                          <div className="text-sm font-medium text-gray-900">{parseHTML(translation.context)}</div>
+                          <div className="text-sm font-medium text-gray-900">{parseHTML(translation.context || '')}</div>
                         ))}
                       </td>
                     </tr>


### PR DESCRIPTION
## Description

The HTML parser (for the word highlighting in the context) now parses an empty string if context is undefined. I recommend looking into saving additional translation and phrase contexts to stop the context from being empty.

## Related Issue

Closes #123 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| :heavy_check_mark:     | :bug: Bug fix              |
