### PR TITLE
setting status to ignore removes userword

### DIFF
--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -33,7 +33,6 @@ const ChangeStatus = function({ word }: { word: UserWord | null }) {
 
     if (status) {
       setCurrentWord(newUserWord);
-
       const updatedWords = [...userWords.filter((wordObj: UserWord) => wordObj.word.toLowerCase()
         !== newUserWord.word.toLowerCase()), newUserWord];
       setUserWords(updatedWords);

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -3,7 +3,10 @@ import {
   ChangeEvent, MouseEvent, useEffect, useState,
 } from 'react';
 
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import {
+  useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState,
+} from 'recoil';
+
 import {
   userwordsState, currentwordState, currenttextState,
   currentwordContextState, userState,
@@ -16,6 +19,7 @@ import translationServices from '../../services/translations';
 const ChangeStatus = function({ word }: { word: UserWord | null }) {
   const [userWords, setUserWords] = useRecoilState(userwordsState);
   const setCurrentWord = useSetRecoilState(currentwordState);
+  const resetCurrentWord = useResetRecoilState(currentwordState);
 
   const user = useRecoilValue(userState);
 
@@ -26,11 +30,19 @@ const ChangeStatus = function({ word }: { word: UserWord | null }) {
     if (newUserWord.id && user) {
       wordsService.updateStatus(newUserWord);
     }
-    setCurrentWord(newUserWord);
 
-    const updatedWords = [...userWords.filter((wordObj: UserWord) => wordObj.word.toLowerCase()
-      !== newUserWord.word.toLowerCase()), newUserWord];
-    setUserWords(updatedWords);
+    if (status) {
+      setCurrentWord(newUserWord);
+
+      const updatedWords = [...userWords.filter((wordObj: UserWord) => wordObj.word.toLowerCase()
+        !== newUserWord.word.toLowerCase()), newUserWord];
+      setUserWords(updatedWords);
+    } else {
+      resetCurrentWord();
+      const updatedWords = [...userWords.filter((wordObj: UserWord) => wordObj.word.toLowerCase()
+        !== newUserWord.word.toLowerCase())];
+      setUserWords(updatedWords);
+    }
   };
 
   const wordStatusToolbar = word


### PR DESCRIPTION
## Description

This fixes issue number 118 on the back end, where setting an `undefined` now results in the word getting removed for the `users_words` table on the back end and from the `userwordState` on the front end. The `currentwordState` is also reset to `null`. 

## Related Issue

Closes #15 
and back end 118

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
| :heavy_check_mark:    | :bug: Bug fix              |
|     | :sparkles: New feature     |
|   :heavy_check_mark:    | :hammer: Refactoring       |

## Testing Steps / QA Criteria

Test with corresponding back end PR. 