### PR TITLE
Settings page error validation

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -34,7 +34,6 @@ const capitalize = function(string: string) {
   return 'English';
 };
 
-
 export default function Navbar() {
   const [languages, setLanguages] = useRecoilState(languagesState);
   const flags = useRecoilValue(languageFlagsState);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -33,12 +33,8 @@ export default function Settings() {
     handleSubmit: handleSubmit2,
     setError: setError2,
     reset,
-    // clearErrors: clearErrors2,
   } = useForm({
     mode: 'onSubmit',
-    // defaultValues: {
-    //   password1: '', password2: '', password3: '',
-    // },
   });
 
   const {
@@ -46,6 +42,7 @@ export default function Settings() {
     formState: { errors: errors3 },
     handleSubmit: handleSubmit3,
     setError: setError3,
+    reset: reset3,
   } = useForm({
     mode: 'onSubmit',
   });
@@ -80,9 +77,9 @@ export default function Settings() {
   };
 
   const changeLanguages = async (data: { currentKnownLanguageId: string; currentLearnLanguageId: string; }) => {
-    console.log(data.currentKnownLanguageId, data.currentLearnLanguageId);
     if (data.currentKnownLanguageId === data.currentLearnLanguageId) {
       setError3('languages', { type: 'languages', message: ' Learning language cannot be the same as known language' });
+      reset3();
       return;
     }
     const response = await userServices.setUserLanguages(data.currentKnownLanguageId, data.currentLearnLanguageId);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -165,12 +165,12 @@ export default function Settings() {
     <form key={1} onSubmit={handleSubmit(changeUserInfo)}>
      <h2 className="text-xl text-gray-600 mb-6 tracking-normal">Update your display name and email</h2>
      <p className="text-sm mb-6 text-green-600 font-bold">{showUserMessage && usermessage}</p>
-      <label className="label sr-only" htmlFor="username">Name</label>
-        <input {...register('username', { required: true, minLength: 3, maxLength: 20 })} id="username" name="username" defaultValue={user.username} className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" type="text" />
+      <label className="label text-sm mb-6" htmlFor="username">Name</label>
+        <input {...register('username', { required: true, minLength: 2, maxLength: 20 })} id="username" name="username" defaultValue={user.username} className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" type="text" />
         {errors.username?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Please enter a user name.</p>)}
         {errors.username?.type === 'minLength' && (<p style={{ color: 'red', fontSize: '14px' }}> Name should have a mininum of 3 characters.</p>)}
         {errors.username?.type === 'maxLength' && (<p style={{ color: 'red', fontSize: '14px' }}> Name should have a maxinum of 20 characters.</p>)}
-        <label htmlFor="email" className="label sr-only">Email</label>
+        <label htmlFor="email" className="label text-sm mb-6">Email</label>
         <input {...register('email', { required: true, pattern: /^\S+@\S+$/i })} id="email" name="email" className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm rounded-b-md"
         defaultValue={user.email} type="email" />
         {errors.email?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Email address is required.</p>)}
@@ -192,19 +192,19 @@ export default function Settings() {
     <h2 className="text-xl text-gray-600 mb-3 tracking-normal">Update your password</h2>
     <p className="text-sm mb-6 text-green-600 font-bold">{showPasswordmessage && passwordmessage}</p>
     <p className="text-gray-600 text-sm mb-6">Update password by providing a new one with the current password.</p>
-     <label htmlFor="password1" className="label sr-only">Password</label>
+     <label htmlFor="password1" className="label text-sm mb-6">Current Password</label>
      <input {...register2('password1', { required: true, pattern: /^.{6,}$/ })}
       className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
       placeholder='Old Password' type="password" />
     {errors2.password1?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Password is required </p>)}
     {errors2.password1?.type === 'pattern' && (<p style={{ color: 'red', fontSize: '14px' }}> The password should have at least 6 characters</p>)}
-    <label htmlFor="password2" className="label sr-only">Password</label>
+    <label htmlFor="password2" className="label text-sm mb-6">New Password</label>
      <input {...register2('password2', { required: true, pattern: /^.{6,}$/ })}
       className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
       placeholder='New Password' type="password" />
     {errors2.password2?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Password is required </p>)}
     {errors2.password2?.type === 'pattern' && (<p style={{ color: 'red', fontSize: '14px' }}> The password should have at least 6 characters</p>)}
-     <label htmlFor="password3" className="label sr-only">New Password</label>
+     <label htmlFor="password3" className="label text-sm mb-6">New Password Again</label>
      <input {...register2('password3', { required: true, pattern: /^.{6,}$/ })}
       className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
       placeholder='Confirm New Password' type="password" />
@@ -231,13 +231,13 @@ export default function Settings() {
     <div className="flex flex-wrap w-full custom-select">
       <label htmlFor="currentKnownLanguageId" className='text-ml font-normal text-gray-700 w-1/3 py-2'>I know</label>
         {<select {...register3('currentKnownLanguageId')} defaultValue={user?.knownLanguageId} className="appearance-none rounded-none relative w-2/3 px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm">
-        {languages.map((lang) => <option key={lang.id} value={lang.id}>{lang.name}</option>)}
+        {languages.map((lang) => <option key={lang.id} value={lang.id}>{lang.flag} {lang.name.charAt(0).toUpperCase() + lang.name.slice(1)}</option>)}
         </select>}
     </div>
     <div className="flex flex-wrap w-full custom-select">
       <label htmlFor="currentLearnLanguageId" className='text-ml font-normal text-gray-700 w-1/3 py-2'>I want to learn</label>
       {<select {...register3('currentLearnLanguageId')} defaultValue={user?.learnLanguageId} className="input appearance-none rounded-none w-2/3 px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm">
-      {languages.map((lang) => <option key={lang.id} value={lang.id}>{lang.name} </option>)}
+      {languages.map((lang) => <option key={lang.id} value={lang.id}>{lang.flag} {lang.name.charAt(0).toUpperCase() + lang.name.slice(1)} </option>)}
       </select>}
       {errors3.languages && (<p style={{ color: 'red', fontSize: '14px' }}>{ errors3.languages.message}</p>)}
     </div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -20,8 +20,9 @@ export default function Settings() {
   const [showPasswordmessage, setShowPasswordmessage] = useState(true);
   const [languagemessage, setLanguagemessage] = useState('');
   const [showLanguageMessage, setShowLanguageMessage] = useState(true);
+
   const {
-    register, formState: { errors }, handleSubmit,
+    register, formState: { errors }, handleSubmit, setError,
   } = useForm({
     mode: 'onSubmit',
   });
@@ -30,7 +31,7 @@ export default function Settings() {
     register: register2,
     formState: { errors: errors2 },
     handleSubmit: handleSubmit2,
-    // setError: setError2,
+    setError: setError2,
   } = useForm({
     mode: 'onSubmit',
   });
@@ -51,22 +52,22 @@ export default function Settings() {
 
   const changeUserInfo = async(data: { username: string; email: string; }) => {
     const response = await userServices.updateInfo(data.username, data.email);
-    setUser(response);
-    setUsermessage('User information updated');
+    if (typeof response === 'object') {
+      setUser(response);
+      setUsermessage('User information updated');
+    } else {
+      setError('email', { type: 'email', message: 'Email already exists.' });
+    }
   };
 
   const changePassword = async (data: { newPassword1: string; newPassword2: string; currentPassword: string; }) => {
-    // if (data.newPassword1 !== data.newPassword2) {
-    //   setError2('password', { type: 'password', message: 'New passwords must match' });
-    //   return;
-    // }
-    // if (data.newPassword1.length < 6) {
-    //   setError2('password', { type: 'passwordLength', message: 'Password must be longer than 6 characters.' });
-    //   return;
-    // }
     const response = await userServices.updatePassword(data.currentPassword, data.newPassword1);
-    setUser(response);
-    setPasswordmessage('Password updated');
+    if (typeof response === 'string') {
+      setError2('password', { type: 'password', message: response });
+    } else {
+      setUser(response);
+      setPasswordmessage('Password updated');
+    }
   };
 
   const changeLanguages = async (data: { currentKnownLanguageId: string; currentLearnLanguageId: string; }) => {
@@ -138,14 +139,15 @@ export default function Settings() {
      <p className="text-sm mb-6 text-green-600 font-bold">{showUserMessage && usermessage}</p>
       <label className="label sr-only" htmlFor="username">Name</label>
         <input {...register('username', { required: true, minLength: 3, maxLength: 20 })} id="username" name="username" defaultValue={user.username} className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" type="text" />
-        {errors.username?.type === 'required' && ' Please enter a user name.'}
-        {errors.username?.type === 'minLength' && ' Name should have a mininum of 3 characters.'}
+        {errors.username?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Please enter a user name.</p>)}
+        {errors.username?.type === 'minLength' && (<p style={{ color: 'red', fontSize: '14px' }}> Name should have a mininum of 3 characters.</p>)}
+        {errors.username?.type === 'maxLength' && (<p style={{ color: 'red', fontSize: '14px' }}> Name should have a maxinum of 20 characters.</p>)}
         <label htmlFor="email" className="label sr-only">Email</label>
         <input {...register('email', { required: true, pattern: /^\S+@\S+$/i })} id="email" name="email" className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm rounded-b-md"
         defaultValue={user.email} type="email" />
-        {errors.email?.type === 'required' && ' Email address is required.'}
-        {errors.email?.type === 'pattern' && ' Please enter an email address.'}
-        {errors.email && errors.email.message}
+        {errors.email?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Email address is required.</p>)}
+        {errors.email?.type === 'pattern' && (<p style={{ color: 'red', fontSize: '14px' }}> Please enter an email address.</p>)}
+        {errors.email && (<p style={{ color: 'red', fontSize: '14px' }}>{ errors.email.message}</p>)}
         <div className='py-6 sm:pt-6 text-right'>
           <button
             type="submit" name="button-name-email"
@@ -164,27 +166,26 @@ export default function Settings() {
     <p className="text-gray-600 text-sm mb-6">Update password by providing a new one with the current password.</p>
      <label htmlFor="current-password" className="label sr-only">Password</label>
      {/* <input {...register('currentPassword', { required: true, pattern: /^.{6,}$/ })} */}
-     <input {...register2('currentPassword')}
+     <input {...register2('password1', { required: true, pattern: /^.{6,}$/ })}
       className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
       placeholder='Old Password' type="password" />
-    {errors2.password?.type === 'required' && ' Password is required.'}
-    {errors2.password?.type === 'pattern' && ' The password should have at least 6 characters.'}
+    {errors2.password1?.type === 'required' && ' Password is required.'}
+    {errors2.password1?.type === 'pattern' && ' The password should have at least 6 characters.'}
     <label htmlFor="new-password" className="label sr-only">Password</label>
      {/* <input {...register('newPassword1', { required: true, pattern: /^.{6,}$/ })} */}
-     <input {...register2('newPassword1')}
+     <input {...register2('password2')}
       className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-      placeholder='Password' type="password" />
-    {errors2.password?.type === 'required' && ' Password is required.'}
-    {errors2.password?.type === 'pattern' && ' The password should have at least 6 characters.'}
+      placeholder='New Password' type="password" />
+    {errors2.password2?.type === 'required' && ' Password is required.'}
+    {errors2.password2?.type === 'pattern' && ' The password should have at least 6 characters.'}
      <label htmlFor="new-password-2" className="label sr-only">New Password</label>
      {/* <input {...register('newPassword2', { required: true, pattern: /^.{6,}$/ })} */}
-     <input {...register2('newPassword2')}
+     <input {...register2('password3')}
       className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
       placeholder='Confirm New Password' type="password" />
-    {/* {errors2.password?.type === 'required' && ' Password is required.'}
-    {errors2.password?.type === 'pattern' && ' The password should have at least 6 characters.'} */}
-    <p className="text-sm mt-6 text-red-600 font-bold">{errors2.password && errors2.password.message}</p>
-    <p className="text-sm mt-6 text-red-600 font-bold">{errors2.passwordLength && errors2.passwordLength.message}</p>
+    {errors2.password3?.type === 'required' && ' Password is required.'}
+    {errors2.password3?.type === 'pattern' && ' The password should have at least 6 characters.'}
+    {errors2.password && (<p style={{ color: 'red', fontSize: '14px' }}>{ errors2.password.message}</p>)}
     <div className='py-6 sm:pt-6 text-right'>
         <button
           type="submit"

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -66,14 +66,29 @@ export default function Settings() {
     const response = await userServices.updatePassword(data.password1, data.password2);
     if (data.password2 !== data.password3) {
       setError2('checkInputPasswords', { type: 'password', message: 'New passwords do not match' });
-      reset();
+
+      const timeId = setTimeout(() => {
+        reset();
+      }, 3000);
+
+      return () => {
+        clearTimeout(timeId);
+      };
     }
+
     if (typeof response === 'string') {
       setError2('password', { type: 'password', message: response });
-      reset();
-    } else {
-      setPasswordmessage('Password updated');
+      const timeId = setTimeout(() => {
+        reset();
+      }, 3000);
+
+      return () => {
+        clearTimeout(timeId);
+      };
     }
+
+    setPasswordmessage('Password updated');
+    return null;
   };
 
   const changeLanguages = async (data: { currentKnownLanguageId: string; currentLearnLanguageId: string; }) => {
@@ -90,7 +105,7 @@ export default function Settings() {
     const response = await userServices.setUserLanguages(data.currentKnownLanguageId, data.currentLearnLanguageId);
     setUser(response);
     setLanguagemessage('Language settings updated');
-    console.log(languagemessage);
+    return null;
   };
 
   useEffect(() => {
@@ -124,7 +139,7 @@ export default function Settings() {
   useEffect(() => {
     const timeId = setTimeout(() => {
       setShowLanguageMessage(false);
-    }, 5000);
+    }, 3000);
 
     return () => {
       clearTimeout(timeId);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -32,6 +32,7 @@ export default function Settings() {
     formState: { errors: errors2 },
     handleSubmit: handleSubmit2,
     setError: setError2,
+    // clearErrors: clearErrors2,
   } = useForm({
     mode: 'onSubmit',
   });
@@ -40,7 +41,7 @@ export default function Settings() {
     register: register3,
     formState: { errors: errors3 },
     handleSubmit: handleSubmit3,
-    // setError: setError3,
+    setError: setError3,
   } = useForm({
     mode: 'onSubmit',
   });
@@ -60,24 +61,28 @@ export default function Settings() {
     }
   };
 
-  const changePassword = async (data: { newPassword1: string; newPassword2: string; currentPassword: string; }) => {
-    const response = await userServices.updatePassword(data.currentPassword, data.newPassword1);
+  const changePassword = async (data: { password1: string; password2: string; password3: string; }) => {
+    const response = await userServices.updatePassword(data.password1, data.password2);
+    if (data.password2 !== data.password3) {
+      setError2('checkInputPasswords', { type: 'password', message: 'New passwords do not match' });
+    }
     if (typeof response === 'string') {
       setError2('password', { type: 'password', message: response });
     } else {
-      setUser(response);
       setPasswordmessage('Password updated');
     }
   };
 
   const changeLanguages = async (data: { currentKnownLanguageId: string; currentLearnLanguageId: string; }) => {
-    // if (data.currentKnownLanguageId === data.currentLearnLanguageId) {
-    //   setError3('learnLanguageId', { type: 'languages', message: ' Learning language cannot be the same as known language' });
-    //   return;
-    // }
+    console.log(data.currentKnownLanguageId, data.currentLearnLanguageId);
+    if (data.currentKnownLanguageId === data.currentLearnLanguageId) {
+      setError3('languages', { type: 'languages', message: ' Learning language cannot be the same as known language' });
+      return;
+    }
     const response = await userServices.setUserLanguages(data.currentKnownLanguageId, data.currentLearnLanguageId);
     setUser(response);
     setLanguagemessage('Language settings updated');
+    console.log(languagemessage);
   };
 
   useEffect(() => {
@@ -165,27 +170,25 @@ export default function Settings() {
     <p className="text-sm mb-6 text-green-600 font-bold">{showPasswordmessage && passwordmessage}</p>
     <p className="text-gray-600 text-sm mb-6">Update password by providing a new one with the current password.</p>
      <label htmlFor="current-password" className="label sr-only">Password</label>
-     {/* <input {...register('currentPassword', { required: true, pattern: /^.{6,}$/ })} */}
      <input {...register2('password1', { required: true, pattern: /^.{6,}$/ })}
       className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
       placeholder='Old Password' type="password" />
-    {errors2.password1?.type === 'required' && ' Password is required.'}
-    {errors2.password1?.type === 'pattern' && ' The password should have at least 6 characters.'}
+    {errors2.password1?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Password is required </p>)}
+    {errors2.password1?.type === 'pattern' && (<p style={{ color: 'red', fontSize: '14px' }}> The password should have at least 6 characters</p>)}
     <label htmlFor="new-password" className="label sr-only">Password</label>
-     {/* <input {...register('newPassword1', { required: true, pattern: /^.{6,}$/ })} */}
-     <input {...register2('password2')}
+     <input {...register2('password2', { required: true, pattern: /^.{6,}$/ })}
       className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
       placeholder='New Password' type="password" />
-    {errors2.password2?.type === 'required' && ' Password is required.'}
-    {errors2.password2?.type === 'pattern' && ' The password should have at least 6 characters.'}
+    {errors2.password2?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Password is required </p>)}
+    {errors2.password2?.type === 'pattern' && (<p style={{ color: 'red', fontSize: '14px' }}> The password should have at least 6 characters</p>)}
      <label htmlFor="new-password-2" className="label sr-only">New Password</label>
-     {/* <input {...register('newPassword2', { required: true, pattern: /^.{6,}$/ })} */}
-     <input {...register2('password3')}
+     <input {...register2('password3', { required: true, pattern: /^.{6,}$/ })}
       className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
       placeholder='Confirm New Password' type="password" />
-    {errors2.password3?.type === 'required' && ' Password is required.'}
-    {errors2.password3?.type === 'pattern' && ' The password should have at least 6 characters.'}
+    {errors2.password3?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Password is required </p>)}
+    {errors2.password3?.type === 'pattern' && (<p style={{ color: 'red', fontSize: '14px' }}> The password should have at least 6 characters</p>)}
     {errors2.password && (<p style={{ color: 'red', fontSize: '14px' }}>{ errors2.password.message}</p>)}
+    {errors2.checkInputPasswords && (<p style={{ color: 'red', fontSize: '14px' }}>{ errors2.checkInputPasswords.message}</p>)}
     <div className='py-6 sm:pt-6 text-right'>
         <button
           type="submit"
@@ -213,7 +216,7 @@ export default function Settings() {
       {<select {...register3('currentLearnLanguageId')} defaultValue={user?.learnLanguageId} className="input appearance-none rounded-none w-2/3 px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm">
       {languages.map((lang) => <option key={lang.id} value={lang.id}>{lang.name} </option>)}
       </select>}
-      <p className="text-sm mt-6 text-red-600 font-bold">{errors3.learnLanguageId && errors3.learnLanguageId.message}</p>
+      {errors3.languages && (<p style={{ color: 'red', fontSize: '14px' }}>{ errors3.languages.message}</p>)}
     </div>
     <div className='py-6 sm:pt-6 text-right'>
           <button

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -32,9 +32,13 @@ export default function Settings() {
     formState: { errors: errors2 },
     handleSubmit: handleSubmit2,
     setError: setError2,
+    reset,
     // clearErrors: clearErrors2,
   } = useForm({
     mode: 'onSubmit',
+    // defaultValues: {
+    //   password1: '', password2: '', password3: '',
+    // },
   });
 
   const {
@@ -65,9 +69,11 @@ export default function Settings() {
     const response = await userServices.updatePassword(data.password1, data.password2);
     if (data.password2 !== data.password3) {
       setError2('checkInputPasswords', { type: 'password', message: 'New passwords do not match' });
+      reset();
     }
     if (typeof response === 'string') {
       setError2('password', { type: 'password', message: response });
+      reset();
     } else {
       setPasswordmessage('Password updated');
     }
@@ -169,19 +175,19 @@ export default function Settings() {
     <h2 className="text-xl text-gray-600 mb-3 tracking-normal">Update your password</h2>
     <p className="text-sm mb-6 text-green-600 font-bold">{showPasswordmessage && passwordmessage}</p>
     <p className="text-gray-600 text-sm mb-6">Update password by providing a new one with the current password.</p>
-     <label htmlFor="current-password" className="label sr-only">Password</label>
+     <label htmlFor="password1" className="label sr-only">Password</label>
      <input {...register2('password1', { required: true, pattern: /^.{6,}$/ })}
       className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
       placeholder='Old Password' type="password" />
     {errors2.password1?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Password is required </p>)}
     {errors2.password1?.type === 'pattern' && (<p style={{ color: 'red', fontSize: '14px' }}> The password should have at least 6 characters</p>)}
-    <label htmlFor="new-password" className="label sr-only">Password</label>
+    <label htmlFor="password2" className="label sr-only">Password</label>
      <input {...register2('password2', { required: true, pattern: /^.{6,}$/ })}
       className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
       placeholder='New Password' type="password" />
     {errors2.password2?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Password is required </p>)}
     {errors2.password2?.type === 'pattern' && (<p style={{ color: 'red', fontSize: '14px' }}> The password should have at least 6 characters</p>)}
-     <label htmlFor="new-password-2" className="label sr-only">New Password</label>
+     <label htmlFor="password3" className="label sr-only">New Password</label>
      <input {...register2('password3', { required: true, pattern: /^.{6,}$/ })}
       className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
       placeholder='Confirm New Password' type="password" />

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -166,12 +166,12 @@ export default function Settings() {
      <h2 className="text-xl text-gray-600 mb-6 tracking-normal">Update your display name and email</h2>
      <p className="text-sm mb-6 text-green-600 font-bold">{showUserMessage && usermessage}</p>
       <label className="label text-sm mb-6" htmlFor="username">Name</label>
-        <input {...register('username', { required: true, minLength: 2, maxLength: 20 })} id="username" name="username" defaultValue={user.username} className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" type="text" />
+        <input {...register('username', { required: true, minLength: 2, maxLength: 20 })} id="username" name="username" defaultValue={user.username} className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" type="text" />
         {errors.username?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Please enter a user name.</p>)}
         {errors.username?.type === 'minLength' && (<p style={{ color: 'red', fontSize: '14px' }}> Name should have a mininum of 3 characters.</p>)}
         {errors.username?.type === 'maxLength' && (<p style={{ color: 'red', fontSize: '14px' }}> Name should have a maxinum of 20 characters.</p>)}
         <label htmlFor="email" className="label text-sm mb-6">Email</label>
-        <input {...register('email', { required: true, pattern: /^\S+@\S+$/i })} id="email" name="email" className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm rounded-b-md"
+        <input {...register('email', { required: true, pattern: /^\S+@\S+$/i })} id="email" name="email" className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
         defaultValue={user.email} type="email" />
         {errors.email?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Email address is required.</p>)}
         {errors.email?.type === 'pattern' && (<p style={{ color: 'red', fontSize: '14px' }}> Please enter an email address.</p>)}
@@ -194,20 +194,17 @@ export default function Settings() {
     <p className="text-gray-600 text-sm mb-6">Update password by providing a new one with the current password.</p>
      <label htmlFor="password1" className="label text-sm mb-6">Current Password</label>
      <input {...register2('password1', { required: true, pattern: /^.{6,}$/ })}
-      className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-      placeholder='Old Password' type="password" />
+      className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" type="password" />
     {errors2.password1?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Password is required </p>)}
     {errors2.password1?.type === 'pattern' && (<p style={{ color: 'red', fontSize: '14px' }}> The password should have at least 6 characters</p>)}
     <label htmlFor="password2" className="label text-sm mb-6">New Password</label>
      <input {...register2('password2', { required: true, pattern: /^.{6,}$/ })}
-      className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-      placeholder='New Password' type="password" />
+      className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" type="password" />
     {errors2.password2?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Password is required </p>)}
     {errors2.password2?.type === 'pattern' && (<p style={{ color: 'red', fontSize: '14px' }}> The password should have at least 6 characters</p>)}
      <label htmlFor="password3" className="label text-sm mb-6">New Password Again</label>
      <input {...register2('password3', { required: true, pattern: /^.{6,}$/ })}
-      className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm"
-      placeholder='Confirm New Password' type="password" />
+      className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" type="password" />
     {errors2.password3?.type === 'required' && (<p style={{ color: 'red', fontSize: '14px' }}> Password is required </p>)}
     {errors2.password3?.type === 'pattern' && (<p style={{ color: 'red', fontSize: '14px' }}> The password should have at least 6 characters</p>)}
     {errors2.password && (<p style={{ color: 'red', fontSize: '14px' }}>{ errors2.password.message}</p>)}
@@ -228,15 +225,15 @@ export default function Settings() {
     <h2 className="text-xl text-gray-600 mb-3 tracking-normal">Update your learning preferences</h2>
     <p className="text-gray-600 text-sm mb-6">Update languages</p>
     <p className="text-sm mb-6 text-green-600 font-bold">{showLanguageMessage && languagemessage}</p>
-    <div className="flex flex-wrap w-full custom-select">
-      <label htmlFor="currentKnownLanguageId" className='text-ml font-normal text-gray-700 w-1/3 py-2'>I know</label>
-        {<select {...register3('currentKnownLanguageId')} defaultValue={user?.knownLanguageId} className="appearance-none rounded-none relative w-2/3 px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm">
+    <div>
+      <label htmlFor="currentKnownLanguageId" className='label text-sm mb-6'>I know</label>
+        {<select {...register3('currentKnownLanguageId')} defaultValue={user?.knownLanguageId} className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm">
         {languages.map((lang) => <option key={lang.id} value={lang.id}>{lang.flag} {lang.name.charAt(0).toUpperCase() + lang.name.slice(1)}</option>)}
         </select>}
     </div>
-    <div className="flex flex-wrap w-full custom-select">
-      <label htmlFor="currentLearnLanguageId" className='text-ml font-normal text-gray-700 w-1/3 py-2'>I want to learn</label>
-      {<select {...register3('currentLearnLanguageId')} defaultValue={user?.learnLanguageId} className="input appearance-none rounded-none w-2/3 px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm">
+    <div>
+      <label htmlFor="currentLearnLanguageId" className='label text-sm mb-6'>I want to learn</label>
+      {<select {...register3('currentLearnLanguageId')} defaultValue={user?.learnLanguageId} className="input appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm">
       {languages.map((lang) => <option key={lang.id} value={lang.id}>{lang.flag} {lang.name.charAt(0).toUpperCase() + lang.name.slice(1)} </option>)}
       </select>}
       {errors3.languages && (<p style={{ color: 'red', fontSize: '14px' }}>{ errors3.languages.message}</p>)}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -79,8 +79,13 @@ export default function Settings() {
   const changeLanguages = async (data: { currentKnownLanguageId: string; currentLearnLanguageId: string; }) => {
     if (data.currentKnownLanguageId === data.currentLearnLanguageId) {
       setError3('languages', { type: 'languages', message: ' Learning language cannot be the same as known language' });
-      reset3();
-      return;
+      const timeId = setTimeout(() => {
+        reset3();
+      }, 5000);
+
+      return () => {
+        clearTimeout(timeId);
+      };
     }
     const response = await userServices.setUserLanguages(data.currentKnownLanguageId, data.currentLearnLanguageId);
     setUser(response);

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -43,7 +43,11 @@ const updateInfo = async function(userName: string, email: string) {
     userName, email,
   }, {
     headers: { Authorization: `bearer ${token}` },
-  });
+  }).then((res) => res)
+    .catch((error) => {
+      const { message } = error.response.data.error;
+      return message;
+    });
 
   return response.data;
 };
@@ -54,8 +58,12 @@ const updatePassword = async function(currentPassword: string, newPassword: stri
     currentPassword, newPassword,
   }, {
     headers: { Authorization: `bearer ${token}` },
-  });
-  return response.data;
+  }).then((res) => res)
+    .catch((error) => {
+      const { message } = error.response.data.error;
+      return message;
+    });
+  return response;
 };
 
 export default {


### PR DESCRIPTION
## Description

Error validation from front end input, as well as backend checks:

1. User info form, you can test:
- Length of input for both user name and email address
- Both fields are filled
- Attempt to update email to an email already existing in DB is rejected

2. Password form, test:
- Old password is correct
- New passwords match
- Passwords are prompted to be of certain length

3. User language settings, test:
- Languages are not the same

Overall, check either success (green) or failure (red) messages show up for each submission attempt.

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? -->

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  x | :bug: Bug fix              |
|     | :sparkles: New feature     |
|  x | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->


### After

<!-- If UI feature, take provide screenshots -->


## Testing Steps / QA Criteria

<!-- Provide steps reviewers need to follow to properly test your additions. -->
