### PR TITLE
Translation form improvements

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -78,7 +78,7 @@ export default function Navbar() {
           <>
             <div className="max-w-7xl mx-auto px-2 sm:px-6 lg:px-8">
               <div className="relative flex items-center justify-between h-16">
-                <div className="absolute inset-y-0 left-0 flex items-center sm:hidden">
+                <div className="absolute inset-y-0 right-0 flex items-center sm:hidden">
 
                   {/* Mobile menu button */}
                   <Disclosure.Button className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
@@ -90,24 +90,23 @@ export default function Navbar() {
                     )}
                   </Disclosure.Button>
                 </div>
-                <div className="flex-1 flex items-center justify-center sm:items-stretch sm:justify-start">
 
                 {/* logo */}
-                <NavLink to={'/about'}>
-                  <div className="flex-shrink-0 flex items-center">
-                    <img
-                      className="block lg:hidden h-8 w-auto"
-                      src={logo}
-                      alt="Alexandria logo"
-                    />
-                    <img
-                      className="hidden lg:block h-8 w-auto"
-                      src={logo}
-                      alt="Alexandria logo"
-                    />
-                  </div>
-                </NavLink>
-
+                <div className="flex items-center justify-center sm:items-start sm:justify-start">
+                  <NavLink to={'/about'}>
+                    <div className="flex-shrink-0 ml-2 sm:ml-0 flex items-center">
+                      <img
+                        className="block lg:hidden h-8 w-auto"
+                        src={logo}
+                        alt="Alexandria logo"
+                      />
+                      <img
+                        className="hidden lg:block h-8 w-auto"
+                        src={logo}
+                        alt="Alexandria logo"
+                      />
+                    </div>
+                  </NavLink>
 
                   {/* These are the navigation buttons e.g. Texts/Vocabulary */}
                   <div className="hidden sm:block sm:ml-6">
@@ -134,7 +133,7 @@ export default function Navbar() {
               </div>
 
               {/* Language dropdown */}
-              <div className="absolute inset-y-0 right-0 flex justify-end items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
+              <div className="flex justify-end mr-8 items-center pr-2 sm:ml-6 sm:pr-0">
                 <Menu as="div" className="sm:ml-3 relative">
                   <div>
                     <Menu.Button className=" flex text-sm">
@@ -147,7 +146,7 @@ export default function Navbar() {
                               'text-gray-300  hover:text-white flex flex-row px-1 sm:px-3 py-2 rounded-md text-sm font-medium',
                             )}
                           >
-                            <p><span className="h-5 w-5 user-lang-flag">{flags[user.learnLanguageId]}</span> {capitalize(names[user.learnLanguageId])}</p>
+                            <p><span className="h-5 w-5 user-lang-flag mr-2">{flags[user.learnLanguageId]}</span> {capitalize(names[user.learnLanguageId])}</p>
                             <svg className="text-gray-400 ml-2 h-5 w-5 group-hover:text-gray-600" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd"></path></svg>
                           </a>
                           }

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -116,6 +116,7 @@ export const Word = function ({ word, dataKey, context }: { word: string, dataKe
 
       if (current.length === 1) {
         setCurrentWord(current[0]);
+        setCurrentWordContext(context);
       }
     } else {
       const selectedWord = input.textContent || '';

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -62,8 +62,8 @@ const ChangeStatus = function({ word }: { word: UserWord | null }) {
 
 const DictionaryIframe = function({ url }: { url: string }) {
   return (
-    <div className=''>
-      <iframe title='Wordreference dictionary' className='' width="320" height="350"
+    <div className='flex justify-center'>
+      <iframe title='Wordreference dictionary' className='' width="350" height="450"
         src={url}>
       </iframe>
     </div>

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -161,7 +161,7 @@ const TranslationComponent = function({ word }:
         <ul className='flex flex-row flex-wrap'>{currentWord?.translations
           .map((transObj) => <li key={`${transObj.id}`} className='p-2 mx-1 shadow-md bg-gray-50 rounded-lg'>{transObj.translation}</li>)}</ul></>}
       {currentWord && <>
-      <div className='py-'>
+      <div className='md:hidden'>
         <p>Context: {currentWordContext}</p>
       </div>
       <div className=''>

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -161,9 +161,9 @@ const TranslationComponent = function({ word }:
         <ul className='flex flex-row flex-wrap'>{currentWord?.translations
           .map((transObj) => <li key={`${transObj.id}`} className='p-2 mx-1 shadow-md bg-gray-50 rounded-lg'>{transObj.translation}</li>)}</ul></>}
       {currentWord && <>
-      <div className='md:hidden'>
+      {currentWordContext && <div className='md:hidden'>
         <p>Context: {currentWordContext}</p>
-      </div>
+      </div>}
       <div className=''>
         <form className=' flex flex-col justify-center' >
           <label htmlFor="translation" className="block text-md">

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -270,8 +270,8 @@ const TranslationInput = function({ word }: { word: UserWord | null }) {
 
   return (
     <>
-      {currentWord && <div id='outer-modal' onClick={(event) => closeModal(event)} className='sm:hidden p-2 fixed inset-0 flex items-end sm:p-6 pointer-events-auto sm:items-start'>
-      <div className='w-full p-4 overflow-scroll pointer-events-auto flex flex-col items-center shadow-lg rounded-lg space-y-4 sm:items-end bg-white'>
+      {currentWord && <div id='outer-modal' onClick={(event) => closeModal(event)} className='sm:hidden h-full p-2 fixed inset-0 flex items-end sm:p-6 pointer-events-auto sm:items-start'>
+      <div className='w-full max-h-full p-4 overflow-scroll pointer-events-auto flex flex-col items-center shadow-lg rounded-lg space-y-4 sm:items-end bg-white'>
         <div className='w-full'>
           <div className='flex flex-row justify-between items-center'>
             <div className='flex flex-row items-center'>

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -44,7 +44,7 @@ const ChangeStatus = function({ word }: { word: UserWord | null }) {
   };
 
   const wordStatusToolbar = word
-    ? <div className="flex flex-row justify-center overflow-visible">
+    ? <div className="flex flex-row text-lg justify-center overflow-visible">
         <button className='bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 px-2 rounded mx-0.5 my-4 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500' onClick={() => setWordStatus('learning', word)} type={'button'}>Learning</button>
         <button className='bg-yellow-500 hover:bg-yellow-600 text-white font-bold py-2 px-2 rounded mx-0.5 my-4 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500' onClick={() => setWordStatus('familiar', word)} type={'button'}>Familiar</button>
         <button className='bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-2 rounded mx-0.5 my-4 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500' onClick={() => setWordStatus('learned', word)} type={'button'}>Learned</button>
@@ -53,7 +53,7 @@ const ChangeStatus = function({ word }: { word: UserWord | null }) {
     : '';
 
   return (
-    <div className="">
+    <div className="mt-3">
       {word && <p className='text-xl'>Current status: {word.status}</p>}
       {wordStatusToolbar}
     </div>
@@ -70,7 +70,8 @@ const DictionaryIframe = function({ url }: { url: string }) {
   );
 };
 
-const TranslationComponent = function({ word }: { word: UserWord | null }) {
+const TranslationComponent = function({ word }:
+{ word: UserWord | null }) {
   const [userWords, setUserWords] = useRecoilState(userwordsState);
   const [currentWord, setCurrentWord] = useRecoilState(currentwordState);
   const currentText = useRecoilValue(currenttextState);
@@ -154,15 +155,18 @@ const TranslationComponent = function({ word }: { word: UserWord | null }) {
   }, [currentWord]);
 
   return (
-    <div key={`translation-component ${word?.id}`}>
+    <div className='text-xl flex flex-col gap-2' key={`translation-component ${word?.id}`}>
       {currentWord && currentWord?.translations?.length > 0
       && <><h2>Current translation{currentWord?.translations?.length > 1 ? 's' : ''}:</h2>
-        <ul className='flex flex-row'>{currentWord?.translations
+        <ul className='flex flex-row flex-wrap'>{currentWord?.translations
           .map((transObj) => <li key={`${transObj.id}`} className='p-2 mx-1 shadow-md bg-gray-50 rounded-lg'>{transObj.translation}</li>)}</ul></>}
       {currentWord && <>
-      <div className='my-4'>
+      <div className='py-2'>
+        <p>Context: {currentWordContext}</p>
+      </div>
+      <div className=''>
         <form className=' flex flex-col justify-center' >
-          <label htmlFor="translation" className="block text-md font-medium text-gray-700">
+          <label htmlFor="translation" className="block text-md">
             Add translation:
           </label>
           <div className="relative rounded-md shadow-sm flex flex-row items-center my-2">
@@ -184,7 +188,7 @@ const TranslationComponent = function({ word }: { word: UserWord | null }) {
         </form>
 
         {/* dictionary buttons and change status */}
-        <div className='flex flex-col justify-center'>
+        <div className='flex flex-col gap-1 justify-center'>
           {showDictionary && <><button onClick={() => setShowDictionary(false)} className='bg-fuchsia-800 hover:bg-fuchsia-700 text-white font-bold py-2 px-4 rounded my-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-fuchsia-600'>Close Dictionary</button>
           <DictionaryIframe url={`${dictionary?.url}/${currentWord.word}`} /></>}
           {!showDictionary && <><p>View word in dictionary:</p>

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -44,7 +44,7 @@ const ChangeStatus = function({ word }: { word: UserWord | null }) {
   };
 
   const wordStatusToolbar = word
-    ? <div className="flex flex-row text-lg justify-center overflow-visible">
+    ? <div className="flex flex-row text-lg max-w-full justify-evenly overflow-visible">
         <button className='bg-orange-500 hover:bg-orange-600 text-white font-bold py-2 px-2 rounded mx-0.5 my-4 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500' onClick={() => setWordStatus('learning', word)} type={'button'}>Learning</button>
         <button className='bg-yellow-500 hover:bg-yellow-600 text-white font-bold py-2 px-2 rounded mx-0.5 my-4 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500' onClick={() => setWordStatus('familiar', word)} type={'button'}>Familiar</button>
         <button className='bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-2 rounded mx-0.5 my-4 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500' onClick={() => setWordStatus('learned', word)} type={'button'}>Learned</button>
@@ -155,13 +155,13 @@ const TranslationComponent = function({ word }:
   }, [currentWord]);
 
   return (
-    <div className='text-xl flex flex-col gap-2' key={`translation-component ${word?.id}`}>
+    <div className='text-xl flex flex-col gap-6' key={`translation-component ${word?.id}`}>
       {currentWord && currentWord?.translations?.length > 0
       && <><h2>Current translation{currentWord?.translations?.length > 1 ? 's' : ''}:</h2>
         <ul className='flex flex-row flex-wrap'>{currentWord?.translations
           .map((transObj) => <li key={`${transObj.id}`} className='p-2 mx-1 shadow-md bg-gray-50 rounded-lg'>{transObj.translation}</li>)}</ul></>}
       {currentWord && <>
-      <div className='py-2'>
+      <div className='py-'>
         <p>Context: {currentWordContext}</p>
       </div>
       <div className=''>
@@ -178,15 +178,15 @@ const TranslationComponent = function({ word }:
               minLength={1}
               onChange={(event) => handleInput(event)}
               value={translation}
-              className="focus:ring-sky-600 focus:border-sky-600 block w-full pl-7 pr-12 sm:text-sm border-gray-300 rounded-md" />
+              className="focus:ring-sky-600 mt-1 focus:border-sky-600 block w-full pl-7 shadow-sm pr-12 sm:text-sm border-gray-300 rounded-md" />
             <button onClick={(event) => {
               handleTranslation(event, translation, word);
               setShowDictionary(false);
               setTranslation('');
-            }} className='bg-sky-600 hover:bg-sky-500 text-white font-bold py-2 ml-1 px-4 rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-500' type={'submit'}>Submit</button>
+            }} className='bg-sky-600 mt-1 hover:bg-sky-500 text-white font-bold py-2 ml-1 px-4 rounded focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-500' type={'submit'}>Submit</button>
           </div>
         </form>
-
+            </div><div>
         {/* dictionary buttons and change status */}
         <div className='flex flex-col gap-1 justify-center'>
           {showDictionary && <><button onClick={() => setShowDictionary(false)} className='bg-fuchsia-800 hover:bg-fuchsia-700 text-white font-bold py-2 px-4 rounded my-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-fuchsia-600'>Close Dictionary</button>
@@ -198,8 +198,11 @@ const TranslationComponent = function({ word }:
           <button onClick={() => window.open(`https://translate.google.com/?sl=${currentText?.languageId}&tl=${user?.knownLanguageId}&text=${currentWord.word}%0A&op=translate/`, 'Google Translate', 'left=100,top=100,width=350,height=550')} className='bg-sky-500 hover:bg-sky-700 text-white font-bold py-2 px-4 rounded my-1'>Google Translate (Popup)</button> */}
           </>}
         </div>
-        {!showDictionary && <ChangeStatus word={word} />}
-      </div></>}
+      </div>
+      <div>
+      {!showDictionary && <ChangeStatus word={word} />}
+      </div>
+      </>}
     </div>
   );
 };


### PR DESCRIPTION
## Description

Added context to translation form, improved spacing
Context only shows on mobile view (in the translation input)
Allow translation div to scroll on mobile when content is longer than screen
Center dictionary iframe when open
Added more spacing and divs to translation input on mobile.
Fixed a bug where context wasn't shown for existing phrases.
Optimized the hero section for laptop screens.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| X  | :bug: Bug fix              |
|     | :sparkles: New feature     |
| X  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->


### After

<!-- If UI feature, take provide screenshots -->


## Testing Steps / QA Criteria

<!-- Provide steps reviewers need to follow to properly test your additions. -->
