### PR TITLE
mh phrase parser

### DIFF
--- a/src/components/texts/Body-Paragraph.tsx
+++ b/src/components/texts/Body-Paragraph.tsx
@@ -18,7 +18,9 @@ const phrasesState = selector({
 const Sentence = function({ sentence }: { sentence: string }) {
   const phrases = useRecoilValue(phrasesState);
 
-  const phraseFinder = phrases.length === 0 ? '' : `(${phrases.join('|')})|`;
+  const phraseRegExps = phrases.map((phrase) => stripPunctuation(phrase).split(' ').join('[^\\p{Letter}\\p{Mark}\'-]+'));
+
+  const phraseFinder = phraseRegExps.length === 0 ? '' : `(${phraseRegExps.join('|')})|`;
   const wordFinder = '(?<words>[\\p{Letter}\\p{Mark}\'-]+)';
   const noWordFinder = '(?<nowords>[^\\p{Letter}\\p{Mark}\'-]+)';
 
@@ -31,7 +33,7 @@ const Sentence = function({ sentence }: { sentence: string }) {
     <>
       {
         tokens?.map((token, index) => {
-          if (phrases.includes(token.toLowerCase())) {
+          if (token.split(' ').length > 1) {
             return <Phrase key={index + token} phrase={token} context={sentence} />;
           }
 

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -12,6 +12,7 @@ import {
   markedwordsState, userwordsState, currentwordState, currentwordContextState, mouseStartXState,
 } from '../../states/recoil-states';
 import { UserWord } from '../../types';
+import { stripPunctuation } from '../../utils/punctuation';
 
 export const Word = function ({ word, dataKey, context }: { word: string, dataKey:string, context: string }) {
   const [userWords, setUserWords] = useRecoilState(userwordsState);
@@ -225,7 +226,7 @@ export const Word = function ({ word, dataKey, context }: { word: string, dataKe
 
 export const Phrase = function ({ phrase, context }: { phrase: string, context: string }) {
   const markedWords = useRecoilValue(markedwordsState);
-  const phraseStatus = markedWords[phrase.toLowerCase()];
+  const phraseStatus = markedWords[stripPunctuation(phrase.toLowerCase())];
 
   let wordClass = '';
 


### PR DESCRIPTION
## Description

The text parser finally matches a non-punctuated phrase from the database with a punctuated version in the text. 

This means we should discuss whether phrase punctuation should actually be saved after all. 

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
| :heavy_check_mark:     | :sparkles: New feature     |
