### PR TITLE
Ea selection fix

### DIFF
--- a/src/components/texts/Body-Paragraph.tsx
+++ b/src/components/texts/Body-Paragraph.tsx
@@ -108,7 +108,7 @@ const TextBody = function ({ title, textBody }: { title: string, textBody: strin
 
   return (
     <>
-      <div onMouseUp={(event) => removeUnusedWordOrGetPhrase(event)} className={`container mx-auto p-4 md:col-span-1 md:col-start-1 bg-white px-4 py-5 shadow sm:rounded-lg sm:px-6 ${currentWord && window.innerWidth < 760 ? 'blur-sm bg-gray-300' : ''}`}>
+      <div onMouseUp={(event) => removeUnusedWordOrGetPhrase(event)} className={`container mx-auto p-4 md:col-span-1 md:col-start-1 bg-white px-4 py-5 shadow sm:rounded-lg sm:px-6 ${currentWord && window.innerWidth < 768 ? 'blur-sm bg-gray-300' : ''}`}>
         <h1 className='font-bold text-3xl mb-2'>{title}</h1>
           {paragraphs.map((paragraph, index) => <div key={index + paragraph.slice(0, 5)} className='mb-3'><Paragraph key={index + paragraph.slice(0, 5)} paragraph={paragraph} /></div>)}
       </div>

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable max-len */
 import {
-  MouseEvent, TouchEvent, useState,
+  TouchEvent, useState,
 } from 'react';
 import {
   useRecoilState,
@@ -9,13 +8,14 @@ import {
 } from 'recoil';
 
 import {
-  markedwordsState, userwordsState, currentwordState, currentwordContextState, mouseStartXState,
+  markedwordsState, userwordsState, currentwordState, currentwordContextState,
 } from '../../states/recoil-states';
 import { UserWord } from '../../types';
 
-export const Word = function ({ word, dataKey, context }: { word: string, dataKey:string, context: string }) {
+export const Word = function ({ word, dataKey, context }:
+{ word: string, dataKey:string, context: string }) {
   const [userWords, setUserWords] = useRecoilState(userwordsState);
-  const [mouseStartX, setMouseStartX] = useRecoilState(mouseStartXState);
+  // const [mouseStartX, setMouseStartX] = useRecoilState(mouseStartXState);
   const setCurrentWordContext = useSetRecoilState(currentwordContextState);
   const setCurrentWord = useSetRecoilState(currentwordState);
   const markedWords = useRecoilValue(markedwordsState);
@@ -26,33 +26,15 @@ export const Word = function ({ word, dataKey, context }: { word: string, dataKe
 
   const wordStatus = markedWords[word.toLowerCase()];
 
-  const isMouseEvent = function(event: TouchEvent | MouseEvent): event is MouseEvent {
-    return (event as MouseEvent).nativeEvent.type === 'mouseup';
-  };
-
-  const getHighlightedWordOrPhrase = function(event: TouchEvent | MouseEvent) {
+  const getHighlightedWordOrPhrase = function() {
     // fix bug where if a user selects backwards, first and last words are swapped
     const selection = window.getSelection();
 
     if (selection?.toString() && selection !== null) {
       const selectedString = selection.toString();
 
-      let startNode;
-      let endNode;
-
-      if (isMouseEvent(event) && mouseStartX) {
-        if (event.clientX < mouseStartX) {
-          endNode = selection.anchorNode;
-          startNode = selection.focusNode;
-        } else {
-          startNode = selection.anchorNode;
-          endNode = selection.focusNode;
-        }
-      } else {
-        startNode = selection.anchorNode;
-        endNode = selection.focusNode;
-      }
-
+      const startNode = selection.anchorNode;
+      const endNode = selection.focusNode;
       const stringArray = selectedString.split(' ');
 
       // ensures the first and last words are whole words
@@ -78,7 +60,18 @@ export const Word = function ({ word, dataKey, context }: { word: string, dataKe
         }
       }
 
-      const newPhrase = stringArray.filter((_, index) => index < 10).join(' ').trim().split('.')[0];
+      let newPhrase = stringArray.filter((_, index) => index < 10).join(' ').trim().split('.')[0];
+      const regex = new RegExp(newPhrase, 'gi');
+
+      // if the phrase is not found in the sentence, then the selection was done backwards
+      if (!regex.test(context)) {
+        const array = newPhrase.split(' ');
+        const end = array[array.length - 1];
+        const start = array[0];
+        const middle = array.filter((_, index) => index !== 0 && index !== array.length - 1);
+        newPhrase = [end, ...middle, start].join(' ');
+      }
+
       const existingWord = userWords.filter((wordObj) => wordObj.word === newPhrase && wordObj.id);
       let newWordObject: UserWord;
 
@@ -112,7 +105,8 @@ export const Word = function ({ word, dataKey, context }: { word: string, dataKe
 
     // checks if user tapped on an existing phrase, if so, show the phrase instead of the word
     if (possiblePhraseDiv?.dataset?.type === 'phrase' && possiblePhraseDiv?.textContent && pointerEvent.type === 'touchend') {
-      const current = userWords.filter((wordObj) => wordObj.word === possiblePhraseDiv?.textContent?.toLowerCase());
+      const current = userWords
+        .filter((wordObj) => wordObj.word === possiblePhraseDiv?.textContent?.toLowerCase());
 
       if (current.length === 1) {
         setCurrentWord(current[0]);
@@ -188,7 +182,7 @@ export const Word = function ({ word, dataKey, context }: { word: string, dataKe
 
           if (touchStart === window.scrollY) {
             if (window.getSelection()?.toString()) {
-              getHighlightedWordOrPhrase(event);
+              getHighlightedWordOrPhrase();
             } else {
               getClickedOnWord(event);
             }
@@ -201,7 +195,7 @@ export const Word = function ({ word, dataKey, context }: { word: string, dataKe
           const pointerEvent = event.nativeEvent as PointerEvent | TouchEvent;
 
           if (window.getSelection()?.toString() && pointerEvent.type === 'mouseup' && !isTouch) {
-            getHighlightedWordOrPhrase(event);
+            getHighlightedWordOrPhrase();
           } else if (pointerEvent.type === 'mouseup' && !isTouch) {
             getClickedOnWord(event);
           }
@@ -210,7 +204,7 @@ export const Word = function ({ word, dataKey, context }: { word: string, dataKe
           setIsTouch(false);
         }}
 
-        onMouseDown={(event) => setMouseStartX(event.clientX)}
+        // onMouseDown={(event) => setMouseStartX(event.clientX)}
         onTouchStart={() => setTouchStart(window.scrollY)}
         onMouseOver={(event) => highlightWordsInPhrases(event.target)}
         className={`${wordClass} ${isWordInPhrase ? 'betterhover:hover:bg-amber-300' : 'betterhover:hover:border-blue-500'} cursor-pointer border border-transparent  py-1 p-px rounded-md`}

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -250,7 +250,7 @@ const TranslationInput = function({ word }: { word: UserWord | null }) {
   if (window.innerWidth > 768) {
     return (
       <>
-        <div className=' md:col-start-2 md:flex flex-col w-[368px] md:col-span-1 hidden'>
+        <div className=' col-start-2 flex flex-col w-[368px] col-span-1 '>
           <div className='sticky top-10 bg-white shadow sm:rounded-lg sm:px-6 py-4 '>
             {word && <div className='flex flex-row items-center'>
               <svg onClick={() => speak()} xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -270,9 +270,9 @@ const TranslationInput = function({ word }: { word: UserWord | null }) {
 
   return (
     <>
-      {currentWord && <div id='outer-modal' onClick={(event) => closeModal(event)} className='sm:hidden h-full p-2 fixed inset-0 flex items-end sm:p-6 pointer-events-auto sm:items-start'>
+      {currentWord && <div id='outer-modal' onClick={(event) => closeModal(event)} className='h-full p-2 fixed inset-0 flex sm:p-6 pointer-events-auto items-end'>
       <div className='w-full max-h-full p-4 overflow-scroll pointer-events-auto flex flex-col items-center shadow-lg rounded-lg space-y-4 sm:items-end bg-white'>
-        <div className='w-full'>
+        <div className='w-full sm:px-4'>
           <div className='flex flex-row justify-between items-center'>
             <div className='flex flex-row items-center'>
               <svg onClick={() => speak()} xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## Description

When a user selected a phrase backwards across more than one line, if the start point was further left than the end point, the words would be swapped. I now check if the selection appears in the context, if not, swap first and last words.

## Related Issue

closes #204 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| X | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Testing Steps / QA Criteria

Test thoroughly, try selecting phrases forwards and backwards, on single lines and across multiple lines.