### PR TITLE
serif headings

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -54,7 +54,7 @@ export default function LoginForm({ from }: { from: string }) {
             src={logo}
             alt="logo"
           />
-          <h2 className=" text-center text-3xl font-serif font-extrabold text-gray-900 py-6">Log in to your account</h2>
+          <h2 className=" text-center text-3xl font-source font-extrabold text-gray-900 py-6">Log in to your account</h2>
         </div>
         <form key={1} className='form-div flex flex-col gap-4' onSubmit={handleSubmit(userInfo)}>
           <div>

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -54,7 +54,7 @@ export default function LoginForm({ from }: { from: string }) {
             src={logo}
             alt="logo"
           />
-          <h2 className=" text-center text-3xl font-extrabold text-gray-900 py-6">Log in to your account</h2>
+          <h2 className=" text-center text-3xl font-serif font-extrabold text-gray-900 py-6">Log in to your account</h2>
         </div>
         <form key={1} className='form-div flex flex-col gap-4' onSubmit={handleSubmit(userInfo)}>
           <div>

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -55,7 +55,7 @@ export default function SignUp() {
           </div>
 
           <div>
-            <h2 className="text-center text-3xl font-extrabold text-gray-900">Sign up for a new account</h2>
+            <h2 className="text-center font-serif text-3xl font-extrabold text-gray-900">Sign up for a new account</h2>
             <p className="text-center">All fields are required.</p>
           </div>
 

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -55,7 +55,7 @@ export default function SignUp() {
           </div>
 
           <div>
-            <h2 className="text-center font-serif text-3xl font-extrabold text-gray-900">Sign up for a new account</h2>
+            <h2 className="text-center font-source text-3xl font-extrabold text-gray-900">Sign up for a new account</h2>
             <p className="text-center">All fields are required.</p>
           </div>
 

--- a/src/components/home/Benefits.tsx
+++ b/src/components/home/Benefits.tsx
@@ -12,7 +12,7 @@ export default function Benefits() {
         {/* Section header */}
           <div className=" flex-1 flex justify-between h-max flex-col gap-6">
           {/* <div className=" flex-1 xl:py-28 flex justify-between h-max flex-col gap-6"> */}
-            <h1 className={`${window.innerHeight < 800 ? 'text-4xl' : 'text-5xl'} font-serif text-center md:text-left xl:text-6xl lg:text-5xl md:text-4xl sm:text-6xl font-extrabold leading-normal tracking-normal`} data-aos="zoom-y-out">Alexandria:<br />Learn languages by<br />
+            <h1 className={`${window.innerHeight < 800 ? 'text-4xl' : 'text-5xl'} font-source text-center md:text-left xl:text-6xl lg:text-5xl md:text-4xl sm:text-6xl font-extrabold leading-normal tracking-normal`} data-aos="zoom-y-out">Alexandria:<br />Learn languages by<br />
               <span className="bg-clip-text block text-transparent bg-gradient-to-r from-[#167cbd] to-[#6a007b]">reading what you enjoy</span>
             </h1>
             <div className="max-w-3xl">

--- a/src/components/home/Benefits.tsx
+++ b/src/components/home/Benefits.tsx
@@ -12,7 +12,7 @@ export default function Benefits() {
         {/* Section header */}
           <div className=" flex-1 flex justify-between h-max flex-col gap-6">
           {/* <div className=" flex-1 xl:py-28 flex justify-between h-max flex-col gap-6"> */}
-            <h1 className={`${window.innerHeight < 800 ? 'text-4xl' : 'text-5xl'} text-center md:text-left xl:text-6xl lg:text-5xl md:text-4xl sm:text-6xl font-extrabold leading-tighter tracking-normal`} data-aos="zoom-y-out">Alexandria:<br />Learn languages by<br />
+            <h1 className={`${window.innerHeight < 800 ? 'text-4xl' : 'text-5xl'} font-serif text-center md:text-left xl:text-6xl lg:text-5xl md:text-4xl sm:text-6xl font-extrabold leading-normal tracking-normal`} data-aos="zoom-y-out">Alexandria:<br />Learn languages by<br />
               <span className="bg-clip-text block text-transparent bg-gradient-to-r from-[#167cbd] to-[#6a007b]">reading what you enjoy</span>
             </h1>
             <div className="max-w-3xl">

--- a/src/components/home/FAQ.tsx
+++ b/src/components/home/FAQ.tsx
@@ -4,12 +4,12 @@ export default function FAQ() {
     <div>
       <div className="bg-lightblue py-20 px-4 md:px-16">
           <div className="mx-auto max-w-6xl flex flex-col md:flex-row">
-              <h2 className="mr-8 w-full md:w-1/3 text-3xl font-extrabold leading-9">
+              <h2 className="mr-8 w-full md:w-1/3 text-3xl font-serif font-extrabold leading-9">
                   Frequently-asked questions
               </h2>
               <dl className="w-full md:w-2/3">
                   <dt className="mb-4">
-                      <h3 className="text-xl font-bold leading-snug tracking-tight mb-1">
+                      <h3 className="text-xl font-bold font-serif leading-snug tracking-tight mb-1">
                           What motivated you all to make this app?
                       </h3>
                   </dt>
@@ -19,7 +19,7 @@ export default function FAQ() {
                       </p>
                   </dd>
                   <dt className="mb-4">
-                      <h3 className="text-xl font-bold leading-snug tracking-tight mb-1">
+                      <h3 className="text-xl font-bold font-serif leading-snug tracking-tight mb-1">
                           Do I need an account to access what Alexandria has to offer?
                       </h3>
                   </dt>
@@ -29,7 +29,7 @@ export default function FAQ() {
                       </p>
                   </dd>
                   <dt className="mb-4">
-                      <h3 className="text-xl font-bold leading-snug tracking-tight mb-1">
+                      <h3 className="text-xl font-bold font-serif leading-snug tracking-tight mb-1">
                           How do you compare with other language learning apps?
                       </h3>
                   </dt>
@@ -39,7 +39,7 @@ export default function FAQ() {
                       </p>
                   </dd>
                   <dt className="mb-4">
-                      <h3 className="text-xl font-bold leading-snug tracking-tight mb-1">
+                      <h3 className="text-xl font-bold font-serif leading-snug tracking-tight mb-1">
                           I have a suggestion for a feature, or found a bug. What should I do?
                       </h3>
                   </dt>
@@ -49,7 +49,7 @@ export default function FAQ() {
                       </p>
                   </dd>
                   <dt className="mb-4">
-                      <h3 className="text-xl font-bold leading-snug tracking-tight mb-1">
+                      <h3 className="text-xl font-bold font-serif leading-snug tracking-tight mb-1">
                           Can I contribute to the project by fixing up a bug or adding a new feature?
                       </h3>
                   </dt>

--- a/src/components/home/FAQ.tsx
+++ b/src/components/home/FAQ.tsx
@@ -4,12 +4,12 @@ export default function FAQ() {
     <div>
       <div className="bg-lightblue py-20 px-4 md:px-16">
           <div className="mx-auto max-w-6xl flex flex-col md:flex-row">
-              <h2 className="mr-8 w-full md:w-1/3 text-3xl font-serif font-extrabold leading-9">
+              <h2 className="mr-8 w-full md:w-1/3 text-3xl font-source font-extrabold leading-9">
                   Frequently-asked questions
               </h2>
               <dl className="w-full md:w-2/3">
                   <dt className="mb-4">
-                      <h3 className="text-xl font-bold font-serif leading-snug tracking-tight mb-1">
+                      <h3 className="text-xl font-bold font-source leading-snug tracking-tight mb-1">
                           What motivated you all to make this app?
                       </h3>
                   </dt>
@@ -19,7 +19,7 @@ export default function FAQ() {
                       </p>
                   </dd>
                   <dt className="mb-4">
-                      <h3 className="text-xl font-bold font-serif leading-snug tracking-tight mb-1">
+                      <h3 className="text-xl font-bold font-source leading-snug tracking-tight mb-1">
                           Do I need an account to access what Alexandria has to offer?
                       </h3>
                   </dt>
@@ -29,7 +29,7 @@ export default function FAQ() {
                       </p>
                   </dd>
                   <dt className="mb-4">
-                      <h3 className="text-xl font-bold font-serif leading-snug tracking-tight mb-1">
+                      <h3 className="text-xl font-bold font-source leading-snug tracking-tight mb-1">
                           How do you compare with other language learning apps?
                       </h3>
                   </dt>
@@ -39,7 +39,7 @@ export default function FAQ() {
                       </p>
                   </dd>
                   <dt className="mb-4">
-                      <h3 className="text-xl font-bold font-serif leading-snug tracking-tight mb-1">
+                      <h3 className="text-xl font-bold font-source leading-snug tracking-tight mb-1">
                           I have a suggestion for a feature, or found a bug. What should I do?
                       </h3>
                   </dt>
@@ -49,7 +49,7 @@ export default function FAQ() {
                       </p>
                   </dd>
                   <dt className="mb-4">
-                      <h3 className="text-xl font-bold font-serif leading-snug tracking-tight mb-1">
+                      <h3 className="text-xl font-bold font-source leading-snug tracking-tight mb-1">
                           Can I contribute to the project by fixing up a bug or adding a new feature?
                       </h3>
                   </dt>

--- a/src/components/home/HowItWorks.tsx
+++ b/src/components/home/HowItWorks.tsx
@@ -36,7 +36,7 @@ export default function HowItWorks() {
                   </g>
                 </g>
               </svg> */}
-              <h4 className="text-xl font-bold leading-snug tracking-tight mt-3 mb-1">Upload text</h4>
+              <h4 className="text-xl font-bold font-serif leading-snug tracking-tight mt-3 mb-1">Upload text</h4>
               <p className="text-gray-600 text-center">Add a piece of text you are interested in reading, in the language you are actively learning. For example, a piece of newspaper article, or a story.</p>
             </div>
 
@@ -53,7 +53,7 @@ export default function HowItWorks() {
                 </g> */}
                  <FontAwesomeIcon icon={faSearch} size='3x' style={{ color: '#0084c7' }}/>
               {/* </svg> */}
-              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1 mt-3">Look up unfamiliar words</h4>
+              <h4 className="text-xl font-bold font-serif leading-snug tracking-tight mb-1 mt-3">Look up unfamiliar words</h4>
               <p className="text-gray-600 text-center">Go through text and click on words you don't know, or are not sure about. Multiple dictionaries are available for translation.</p>
             </div>
 
@@ -69,7 +69,7 @@ export default function HowItWorks() {
                 </g>
               </svg> */}
               <FontAwesomeIcon icon={faAdjust} size='3x' style={{ color: '#0084c7' }}/>
-              <h4 className="text-xl font-bold leading-snug tracking-tight mt-3 mb-1">Set learned status</h4>
+              <h4 className="text-xl font-bold font-serif leading-snug tracking-tight mt-3 mb-1">Set learned status</h4>
               <p className="text-gray-600 text-center">Inititally marked words are marked with a "learned status" of "Learning". But feel free to adjust it based on your level of familiarity with the word.</p>
             </div>
 
@@ -87,7 +87,7 @@ export default function HowItWorks() {
                 </g>
               </svg> */}
               <FontAwesomeIcon icon={faCommentDots} size='3x' style={{ color: '#0084c7' }}/>
-              <h4 className="text-xl font-bold leading-snug tracking-tight mt-3 mb-1">Apply translation in context</h4>
+              <h4 className="text-xl font-bold font-serif leading-snug tracking-tight mt-3 mb-1">Apply translation in context</h4>
               <p className="text-gray-600 text-center">Based on surrounding context, add the translation that fit best. You can always add another translation for the same word based on a different context later.</p>
             </div>
 
@@ -103,7 +103,7 @@ export default function HowItWorks() {
                 </g>
               </svg> */}
               <FontAwesomeIcon icon={faCheck} size='3x' style={{ color: '#0084c7' }}/>
-              <h4 className="text-xl font-bold leading-snug tracking-tight mt-3 mb-1">Adjust learned status</h4>
+              <h4 className="text-xl font-bold font-serif leading-snug tracking-tight mt-3 mb-1">Adjust learned status</h4>
               <p className="text-gray-600 text-center">If previously marked words already exist in your account, they are shown based on "learned status". Adjust status based on your level of familiarity with the word.</p>
             </div>
 
@@ -121,7 +121,7 @@ export default function HowItWorks() {
                 </g>
               </svg> */}
               <FontAwesomeIcon icon={faChalkboardTeacher} size='3x' style={{ color: '#0084c7' }}/>
-              <h4 className="text-xl font-bold leading-snug tracking-tight mt-3 mb-1">Review word list</h4>
+              <h4 className="text-xl font-bold font-serif leading-snug tracking-tight mt-3 mb-1">Review word list</h4>
               <p className="text-gray-600 text-center">Marked words are available for review at your convenience. Words are presented with translation and surrounding context to ensure maximum retention.</p>
             </div>
 

--- a/src/components/home/HowItWorks.tsx
+++ b/src/components/home/HowItWorks.tsx
@@ -36,7 +36,7 @@ export default function HowItWorks() {
                   </g>
                 </g>
               </svg> */}
-              <h4 className="text-xl font-bold font-serif leading-snug tracking-tight mt-3 mb-1">Upload text</h4>
+              <h4 className="text-xl font-bold font-source leading-snug tracking-tight mt-3 mb-1">Upload text</h4>
               <p className="text-gray-600 text-center">Add a piece of text you are interested in reading, in the language you are actively learning. For example, a piece of newspaper article, or a story.</p>
             </div>
 
@@ -53,7 +53,7 @@ export default function HowItWorks() {
                 </g> */}
                  <FontAwesomeIcon icon={faSearch} size='3x' style={{ color: '#0084c7' }}/>
               {/* </svg> */}
-              <h4 className="text-xl font-bold font-serif leading-snug tracking-tight mb-1 mt-3">Look up unfamiliar words</h4>
+              <h4 className="text-xl font-bold font-source leading-snug tracking-tight mb-1 mt-3">Look up unfamiliar words</h4>
               <p className="text-gray-600 text-center">Go through text and click on words you don't know, or are not sure about. Multiple dictionaries are available for translation.</p>
             </div>
 
@@ -69,7 +69,7 @@ export default function HowItWorks() {
                 </g>
               </svg> */}
               <FontAwesomeIcon icon={faAdjust} size='3x' style={{ color: '#0084c7' }}/>
-              <h4 className="text-xl font-bold font-serif leading-snug tracking-tight mt-3 mb-1">Set learned status</h4>
+              <h4 className="text-xl font-bold font-source leading-snug tracking-tight mt-3 mb-1">Set learned status</h4>
               <p className="text-gray-600 text-center">Inititally marked words are marked with a "learned status" of "Learning". But feel free to adjust it based on your level of familiarity with the word.</p>
             </div>
 
@@ -87,7 +87,7 @@ export default function HowItWorks() {
                 </g>
               </svg> */}
               <FontAwesomeIcon icon={faCommentDots} size='3x' style={{ color: '#0084c7' }}/>
-              <h4 className="text-xl font-bold font-serif leading-snug tracking-tight mt-3 mb-1">Apply translation in context</h4>
+              <h4 className="text-xl font-bold font-source leading-snug tracking-tight mt-3 mb-1">Apply translation in context</h4>
               <p className="text-gray-600 text-center">Based on surrounding context, add the translation that fit best. You can always add another translation for the same word based on a different context later.</p>
             </div>
 
@@ -103,7 +103,7 @@ export default function HowItWorks() {
                 </g>
               </svg> */}
               <FontAwesomeIcon icon={faCheck} size='3x' style={{ color: '#0084c7' }}/>
-              <h4 className="text-xl font-bold font-serif leading-snug tracking-tight mt-3 mb-1">Adjust learned status</h4>
+              <h4 className="text-xl font-bold font-source leading-snug tracking-tight mt-3 mb-1">Adjust learned status</h4>
               <p className="text-gray-600 text-center">If previously marked words already exist in your account, they are shown based on "learned status". Adjust status based on your level of familiarity with the word.</p>
             </div>
 
@@ -121,7 +121,7 @@ export default function HowItWorks() {
                 </g>
               </svg> */}
               <FontAwesomeIcon icon={faChalkboardTeacher} size='3x' style={{ color: '#0084c7' }}/>
-              <h4 className="text-xl font-bold font-serif leading-snug tracking-tight mt-3 mb-1">Review word list</h4>
+              <h4 className="text-xl font-bold font-source leading-snug tracking-tight mt-3 mb-1">Review word list</h4>
               <p className="text-gray-600 text-center">Marked words are available for review at your convenience. Words are presented with translation and surrounding context to ensure maximum retention.</p>
             </div>
 

--- a/src/components/texts/Body-Paragraph.tsx
+++ b/src/components/texts/Body-Paragraph.tsx
@@ -111,7 +111,7 @@ const TextBody = function ({ title, textBody }: { title: string, textBody: strin
   return (
     <>
       <div onMouseUp={(event) => removeUnusedWordOrGetPhrase(event)} className={`container mx-auto p-4 md:col-span-1 md:col-start-1 bg-white px-4 py-5 shadow sm:rounded-lg sm:px-6 ${currentWord && window.innerWidth < 760 ? 'blur-sm bg-gray-300' : ''}`}>
-        <h1 className='font-bold text-3xl mb-2'>{title}</h1>
+        <h1 className='font-bold font-serif text-3xl mb-2'>{title}</h1>
           {paragraphs.map((paragraph, index) => <div key={index + paragraph.slice(0, 5)} className='mb-3'><Paragraph key={index + paragraph.slice(0, 5)} paragraph={paragraph} /></div>)}
       </div>
     </>

--- a/src/components/texts/Body-Paragraph.tsx
+++ b/src/components/texts/Body-Paragraph.tsx
@@ -111,7 +111,7 @@ const TextBody = function ({ title, textBody }: { title: string, textBody: strin
   return (
     <>
       <div onMouseUp={(event) => removeUnusedWordOrGetPhrase(event)} className={`container mx-auto p-4 md:col-span-1 md:col-start-1 bg-white px-4 py-5 shadow sm:rounded-lg sm:px-6 ${currentWord && window.innerWidth < 760 ? 'blur-sm bg-gray-300' : ''}`}>
-        <h1 className='font-bold font-serif text-3xl mb-2'>{title}</h1>
+        <h1 className='font-bold font-source text-3xl mb-2'>{title}</h1>
           {paragraphs.map((paragraph, index) => <div key={index + paragraph.slice(0, 5)} className='mb-3'><Paragraph key={index + paragraph.slice(0, 5)} paragraph={paragraph} /></div>)}
       </div>
     </>

--- a/src/components/texts/UserTexts.tsx
+++ b/src/components/texts/UserTexts.tsx
@@ -39,7 +39,7 @@ const IndividualText = function({ text, setOpenModal, setTextToDelete }:
             </div>
             <div className='flex-1 truncate'>
               <div className="flex items-center space-x-3">
-                <h2 className='text-gray-900 text-xl font-medium truncate'>{text.title}</h2>
+                <h2 className='text-gray-900 text-xl font-bold font-serif truncate'>{text.title}</h2>
               </div>
               <p className='mt-1 text-gray-500 text-sm truncate'>{`${text.body.slice(0, 97)}...`}</p>
             </div>

--- a/src/components/texts/UserTexts.tsx
+++ b/src/components/texts/UserTexts.tsx
@@ -39,7 +39,7 @@ const IndividualText = function({ text, setOpenModal, setTextToDelete }:
             </div>
             <div className='flex-1 truncate'>
               <div className="flex items-center space-x-3">
-                <h2 className='text-gray-900 text-xl font-bold font-serif truncate'>{text.title}</h2>
+                <h2 className='text-gray-900 text-xl font-bold font-source truncate'>{text.title}</h2>
               </div>
               <p className='mt-1 text-gray-500 text-sm truncate'>{`${text.body.slice(0, 97)}...`}</p>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Source+Serif+Pro:wght@900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,9 @@ module.exports = {
         screens: {
           'betterhover': {'raw': '(hover: hover)'},
         },
+        fontFamily: {
+          'source': ['Source Serif Pro'],
+        },
     }
   },
   plugins: [


### PR DESCRIPTION
## Description

In a bid to differentiate the look from the elreader default I set our headings to `font-serif`. I think it looks interesting and already quite good. Could be even better with a different, slightly wider serif font, like ["Source Serif Pro"](https://fonts.google.com/specimen/Source+Serif+Pro) (as seen on [bluehost.com](https://bluehost.com)). Let me know what you think.