### PR TITLE
Ea improvments fixes

### DIFF
--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -142,11 +142,11 @@ export default function SignUp() {
           </div>
 
           <div>
-            <div className="userFields" aria-hidden="true">
+            <div className="userFields hidden" aria-hidden="true">
               <label className="label phone">Phone number</label>
               <input {...register('phone')} className="input phone" type="text" tabIndex={-1}/>
               <label className="label website">Website</label>
-              <input {...register('website')} className="input website" type="text" tabIndex={-1}/>
+              <input {...register('website')} className="input website hidden" type="text" tabIndex={-1}/>
             </div>
             <button
               type="submit"

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -152,8 +152,6 @@ export const Word = function ({ word, dataKey, context }:
     wordClass = 'bg-orange-400';
   } else if (wordStatus === 'familiar') {
     wordClass = 'bg-yellow-300';
-  } else if (wordStatus === 'learned') {
-    wordClass = 'bg-green-200';
   }
 
   const isElement = function(element: Element | EventTarget): element is Element {
@@ -176,7 +174,7 @@ export const Word = function ({ word, dataKey, context }:
   // const setMouseStartX = function () {};
 
   return (
-    <div className='inline-block my-1.5'>
+    <div className='inline-block text-lg my-1.5'>
       <span
         onTouchEnd={(event) => {
           setIsTouch(true);

--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -174,7 +174,7 @@ export const Word = function ({ word, dataKey, context }:
   // const setMouseStartX = function () {};
 
   return (
-    <div className='inline-block text-lg my-1.5'>
+    <div className='inline-block text-xl md:text-lg my-2 md:my-1.5'>
       <span
         onTouchEnd={(event) => {
           setIsTouch(true);
@@ -206,7 +206,7 @@ export const Word = function ({ word, dataKey, context }:
         // onMouseDown={(event) => setMouseStartX(event.clientX)}
         onTouchStart={() => setTouchStart(window.scrollY)}
         onMouseOver={(event) => highlightWordsInPhrases(event.target)}
-        className={`${wordClass} ${isWordInPhrase ? 'betterhover:hover:bg-amber-300' : 'betterhover:hover:border-blue-500'} cursor-pointer border border-transparent  py-1 p-px rounded-md`}
+        className={`${wordClass} ${isWordInPhrase ? 'betterhover:hover:bg-amber-300' : 'betterhover:hover:border-blue-500'} cursor-pointer border border-transparent py-2 md:py-1 p-px rounded-md`}
         data-key={dataKey}
         data-type={'word'}>
         {word}
@@ -240,8 +240,8 @@ export const Phrase = function ({ phrase, context }: { phrase: string, context: 
 
   return (
     <>
-      <div className='inline'>
-        <span className={`${wordClass} cursor-pointer m-[-1px] border border-transparent betterhover:hover:border-zinc-500 hover:py-2.5 py-1.5 rounded-md`} data-type={'phrase'}>
+      <div className='inline text-xl md:text-lg'>
+        <span className={`${wordClass} cursor-pointer m-[-1px] border border-transparent betterhover:hover:border-zinc-500 hover:py-2.5 md:py-1.5 py-2 rounded-md`} data-type={'phrase'}>
       {/* {
         parts.map((word, index, array) => <Fragment key={index + word} >
           <Word key={index + word} dataKey={index + word} word={word} context={context} />

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -16,6 +16,7 @@ import {
 import { UserWord, Status, Translation } from '../../types';
 import wordsService from '../../services/words';
 import translationServices from '../../services/translations';
+import shortenContext from '../../utils/shortenContext';
 
 const ChangeStatus = function({ word }: { word: UserWord | null }) {
   const [userWords, setUserWords] = useRecoilState(userwordsState);
@@ -252,7 +253,12 @@ const TranslationComponent = function({ word }:
     }
   }, [currentWord]);
 
-  const regex = new RegExp(`${currentWord?.word}`, 'ig');
+  const regex = new RegExp(`\\b${currentWord?.word}\\b`, 'ig');
+
+  let shortenedContext = '';
+  if (currentWord?.word && currentWordContext) {
+    shortenedContext = shortenContext(currentWord.word, currentWordContext).replaceAll(regex, (match) => `<strong>${match}</strong>`);
+  }
 
   return (
     <div className='text-md flex text-lg sm:text-sm flex-col gap-4 mt-2' key={`translation-component ${word?.id}`}>
@@ -294,8 +300,7 @@ const TranslationComponent = function({ word }:
          </div></>}
       {currentWord && <>
       {currentWordContext && <div className='md:hidden flex flex-col gap-1'>
-        {/* <p>Context:</p> */}
-        <p>{parseHTML(currentWordContext.replaceAll(regex, (match) => `<strong>${match}</strong>`))}</p>
+        <p>{parseHTML(shortenedContext)}</p>
       </div>}
       <div>
         {/* dictionary buttons and change status */}
@@ -329,8 +334,7 @@ const TranslationInput = function({ word }: { word: UserWord | null }) {
     return (element as Element).nodeName !== undefined;
   };
 
-  const closeModal = function(event:
-  MouseEvent<HTMLDivElement, globalThis.MouseEvent>) {
+  const closeModal = function(event: MouseEvent) {
     event?.preventDefault();
     const element = event.target;
     if (isElement(element) && (element.id === 'outer-modal' || element.id === 'close-modal')) {

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable max-len */
 import {
   ChangeEvent, MouseEvent, useEffect, useState, Suspense, FormEvent,
@@ -178,7 +179,7 @@ const TranslationComponent = function({ word }:
   const user = useRecoilValue(userState);
 
   const handleTranslation = async function(
-    event: FormEvent<HTMLFormElement>,
+    event: MouseEvent<HTMLFormElement, globalThis.MouseEvent>,
     translation: string,
     userWord: UserWord | null,
   ) {
@@ -267,17 +268,18 @@ const TranslationComponent = function({ word }:
           </label>
             <div className="grid grid-cols-3 gap-6">
               <div className="col-span-3">
-
-                <form onSubmit={(event) => {
+                <form onClick={(event) => {
                   handleTranslation(event, translation, word);
                   setShowDictionary(false);
                   setTranslation('');
                 }}
-                    className="group flex rounded-md">
+                  action=''
+                  className="group flex rounded-md">
                   <button
                   type='submit'
-                  className={`inline-flex shadow-none order-2 w-[55px] items-center px-3 rounded-r-md border border-l-0 border-gray-300 ${translation ? 'bg-sky-600 text-white border-0' : 'bg-gray-50 text-gray-500 pointer-events-none'} text-sm`} >
-                    Save
+                  className={`inline-flex shadow-none order-2 w-[55px] items-center px-3 rounded-r-md border border-l-0 border-gray-300 ${translation ? 'bg-sky-600 text-white border-0' : 'bg-gray-50 text-gray-500 pointer-events-none'} text-sm`}
+                  >
+                  Save
                   </button>
                   <input
                     type="text"
@@ -379,13 +381,13 @@ const TranslationInput = function({ word }: { word: UserWord | null }) {
         <div className='w-full sm:px-4'>
           <div className='flex flex-row justify-between items-center'>
             <div className='flex flex-row items-center'>
-              <svg onClick={() => speak()} xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg onClick={() => speak()} xmlns="http://www.w3.org/2000/svg" className="h-11 w-11 p-2 -mt-1 -ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" />
               </svg>
-              <h2 className=' ml-2 text-3xl font-medium text-gray-900 mb-2'>{word ? `${word.word}` : 'Select a word'}</h2>
+              <h2 className='text-3xl font-medium text-gray-900 mb-2 '>{word ? `${word.word}` : 'Select a word'}</h2>
             </div>
-            <div onClick={(event) => closeModal(event)} className='flex flex-row items-center'>
-              <svg id='close-modal' xmlns="http://www.w3.org/2000/svg" className="h-7 w-7" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <div onClick={(event) => closeModal(event)} className='flex flex-row items-center '>
+              <svg id='close-modal' xmlns="http://www.w3.org/2000/svg" className="h-11 w-11 p-2 " fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </div>

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -320,7 +320,7 @@ const TranslationComponent = function({ word }:
 
 const TranslationInput = function({ word }: { word: UserWord | null }) {
   const [currentWord, setCurrentWord] = useRecoilState(currentwordState);
-
+  const [userWords, setUserWords] = useRecoilState(userwordsState);
   const user = useRecoilValue(userState);
 
   const voices = window.speechSynthesis.getVoices();
@@ -336,6 +336,9 @@ const TranslationInput = function({ word }: { word: UserWord | null }) {
     if (isElement(element) && (element.id === 'outer-modal' || element.id === 'close-modal')) {
       setCurrentWord(null);
     }
+
+    const updatedWords = userWords.filter((wordObj: UserWord) => wordObj.id);
+    setUserWords(updatedWords);
   };
 
   // specific language variants can be added

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import {
-  ChangeEvent, MouseEvent, useEffect, useState, Suspense,
+  ChangeEvent, MouseEvent, useEffect, useState, Suspense, FormEvent,
 } from 'react';
 import parseHTML from 'html-react-parser';
 import {
@@ -46,7 +46,7 @@ const ChangeStatus = function({ word }: { word: UserWord | null }) {
 
   const wordStatusToolbar = word
     ? <div className={'flex flex-row text-md sm:text-sm max-w-fit border border-gray-300 justify-center gap-0 rounded-md overflow-visible '}>
-        <button className={`hover:bg-orange-600 rounded-l-md has-tooltip border-r flex flex-col group place-content-center hover:text-white py-2 px-2  focus:outline-none focus:ring-2 focus:ring-offset-2 ${word.status === 'learning' ? 'bg-orange-600 text-white' : ''} focus:ring-orange-500`} onClick={() => setWordStatus('learning', word)} title='Learning' type={'button'}>
+        <button className={`hover:bg-orange-600 rounded-l-md has-tooltip border-r flex flex-col group place-content-center hover:text-white py-2 px-2  focus:outline-none focus:ring-2 focus:ring-offset-1 ${word.status === 'learning' ? 'bg-orange-600 text-white' : ''} focus:ring-orange-500`} onClick={() => setWordStatus('learning', word)} title='Learning' type={'button'}>
           {/* <svg xmlns="http://www.w3.org/2000/svg" className="h-7 w-7 group-hover:text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path d="M12 14l9-5-9-5-9 5 9 5z" />
             <path d="M12 14l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z" />
@@ -54,21 +54,21 @@ const ChangeStatus = function({ word }: { word: UserWord | null }) {
           </svg> */}
           Learning
         </button>
-        <button className={`hover:bg-yellow-600 has-tooltip flex flex-col border-r border-gray-300 group place-content-center hover:text-white py-2 px-2 focus:outline-none focus:ring-2 focus:ring-offset-2 ${word.status === 'familiar' ? 'bg-yellow-600 text-white' : ''} focus:ring-yellow-500`} onClick={() => setWordStatus('familiar', word)} title='Familiar' type={'button'}>
+        <button className={`hover:bg-yellow-600 has-tooltip flex flex-col border-r border-gray-300 group place-content-center hover:text-white py-2 px-2 focus:outline-none focus:ring-2 focus:ring-offset-1 ${word.status === 'familiar' ? 'bg-yellow-600 text-white' : ''} focus:ring-yellow-500`} onClick={() => setWordStatus('familiar', word)} title='Familiar' type={'button'}>
           {/* <span className='tooltip bg-yellow-600'>Familiar</span>
           <svg xmlns="http://www.w3.org/2000/svg" className="h-7 w-7 group-hover:text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
           </svg> */}
           Familiar
         </button>
-        <button className={`hover:bg-green-600 has-tooltip  flex flex-col group place-content-center hover:text-white py-2 px-2  focus:outline-none focus:ring-2 focus:ring-offset-2 ${word.status === 'learned' ? 'bg-green-600 text-white' : ''} focus:ring-green-500`} onClick={() => setWordStatus('learned', word)} title='Learned' type={'button'}>
+        <button className={`hover:bg-green-600 has-tooltip  flex flex-col group place-content-center hover:text-white py-2 px-2  focus:outline-none focus:ring-2 focus:ring-offset-1 ${word.status === 'learned' ? 'bg-green-600 text-white' : ''} focus:ring-green-500`} onClick={() => setWordStatus('learned', word)} title='Learned' type={'button'}>
           {/* <span className='tooltip bg-green-600'>Learned</span>
           <svg xmlns="http://www.w3.org/2000/svg" className="h-7 w-7 text-green-600 group-hover:text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
           </svg> */}
           Learned
         </button>
-        <button className={`hover:bg-red-600 has-tooltip rounded-r-md border-gray-300 border-l bord flex flex-col group place-content-center align-center hover:text-white py-2 px-2  focus:outline-none focus:ring-2 focus:ring-offset-2 ${word.status === undefined ? 'bg-red-600 text-white' : ''} focus:ring-red-500`} onClick={() => setWordStatus(undefined, word)} title='Ignore' type={'button'}>
+        <button className={`hover:bg-red-600 has-tooltip rounded-r-md border-gray-300 border-l bord flex flex-col group place-content-center align-center hover:text-white py-2 px-2  focus:outline-none focus:ring-2 focus:ring-offset-1 ${word.status === undefined ? 'bg-red-600 text-white' : ''} focus:ring-red-500`} onClick={() => setWordStatus(undefined, word)} title='Ignore' type={'button'}>
           {/* <span className='tooltip bg-red-600'>Ignore</span>
           <svg xmlns="http://www.w3.org/2000/svg" className="h-7 w-7 text-red-600 group-hover:text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
@@ -79,9 +79,7 @@ const ChangeStatus = function({ word }: { word: UserWord | null }) {
     : '';
 
   return (
-    // <div className="mt-3">
     <div className="">
-      {/* {word && <p className=''>Current status: {word.status}</p>} */}
       {wordStatusToolbar}
     </div>
   );
@@ -177,11 +175,10 @@ const TranslationComponent = function({ word }:
   const currentText = useRecoilValue(currenttextState);
   const currentWordContext = useRecoilValue(currentwordContextState);
   const dictionary = useRecoilValue(currentdictionaryState);
-
   const user = useRecoilValue(userState);
 
   const handleTranslation = async function(
-    event: MouseEvent<HTMLFormElement, globalThis.MouseEvent>,
+    event: FormEvent<HTMLFormElement>,
     translation: string,
     userWord: UserWord | null,
   ) {
@@ -271,7 +268,7 @@ const TranslationComponent = function({ word }:
             <div className="grid grid-cols-3 gap-6">
               <div className="col-span-3">
 
-                <form onClick={(event) => {
+                <form onSubmit={(event) => {
                   handleTranslation(event, translation, word);
                   setShowDictionary(false);
                   setTranslation('');

--- a/src/utils/shortenContext.ts
+++ b/src/utils/shortenContext.ts
@@ -1,0 +1,8 @@
+const shortenContext = function(word: string, context: string) {
+  const regex = new RegExp(`(\\S+[ \\b]){0,5}\\b${word}\\b([ \\b]*\\S+[ \\b]*){0,5}`, 'gi');
+  const match = context.match(regex);
+  const shortenedContext = match?.[0] || context;
+  return shortenedContext;
+};
+
+export default shortenContext;


### PR DESCRIPTION
## Description

Fixed a bug where the honeypot fields were not hidden
Reduced focus ring around status buttons. Fixed a bug where dictionary would close when trying to add a new translation.
Increased text font size
Added bigger touch targets for sound and x icons on mobile translation view
On mobile, closing the modal without adding a translation no longer leaves the word highlighted
Increased touch targets on words when reading a text on mobile
Added basic regex to shorten the context on mobile. Still needs some refinement

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| X  | :bug: Bug fix              |
| X  | :sparkles: New feature     |
| X  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

