### PR TITLE
Mh token fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import userServices from './services/users';
 function App() {
   const [user, setUser] = useRecoilState(userState);
   const [errorState, setErrorState] = useState(false);
+
   const defaultDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   const [theme] = useLocalStorage('theme', defaultDark ? 'dark' : 'light');
 
@@ -30,11 +31,10 @@ function App() {
       const localToken = getToken();
 
       if (typeof localToken === 'string') {
-        const tokenUser = await userServices.getUserFromToken(localToken);
-
-        if (tokenUser.username) {
+        try {
+          const tokenUser = await userServices.getUserFromToken(localToken);
           setUser(tokenUser);
-        } else {
+        } catch (error) {
           localStorage.removeItem('alexandria-user-token');
         }
       }
@@ -47,7 +47,7 @@ function App() {
 
   useEffect(() => {
     fetchUserInfo();
-  }, []);
+  });
 
   return (
     <div className="min-h-screen min-w-full text-primary bg-secondary flex flex-col justify-between  mb-auto">

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { useRecoilValue } from 'recoil';
 import { userState } from '../states/recoil-states';
 
@@ -8,18 +8,19 @@ import FAQ from './home/FAQ';
 
 export default function Home() {
   const user = useRecoilValue(userState);
-  const navigate = useNavigate();
 
   return (
   // <div className='home-page'>
-     <> { user
-       ? navigate('/texts')
-       : <>
-          <Hero />
-          <HowItWorks />
-          <FAQ />
-        </>
-     } </>
+     <>
+     {
+        !user
+          ? <>
+              <Hero />
+              <HowItWorks />
+              <FAQ />
+            </>
+          : <Navigate to="/texts"/>
+      } </>
   // </div>
   );
 }

--- a/src/components/LogIn.tsx
+++ b/src/components/LogIn.tsx
@@ -1,14 +1,23 @@
-import { Location, useLocation } from 'react-router';
+import { Location, Navigate, useLocation } from 'react-router';
+import { useRecoilValue } from 'recoil';
+import { userState } from '../states/recoil-states';
 import LoginForm from './LoginForm';
 
 export default function LogIn() {
+  const user = useRecoilValue(userState);
   const location = useLocation();
   const state = location.state as { from: Location };
   const from = state ? state.from?.pathname : '/texts';
 
   return (
-    <main className='container mx-auto mb-auto'>
-      <LoginForm from={from} />
-    </main>
+    <>
+    {
+      !user
+        ? <main className='container mx-auto mb-auto'>
+            <LoginForm from={from} />
+          </main>
+        : <Navigate to={from} />
+    }
+    </>
   );
 }

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -20,7 +20,7 @@ export default function LoginForm({ from }: { from: string }) {
 
   const navigate = useNavigate();
 
-  const userInfo = (async (data: { email: string; password: string; }) => {
+  const userInfo = async (data: { email: string; password: string; }) => {
     const newUserData = {
       email: data.email,
       password: data.password,
@@ -42,8 +42,7 @@ export default function LoginForm({ from }: { from: string }) {
     localStorage.setItem('alexandria-user-token', response.token);
     navigate(from);
     return null;
-  }
-  );
+  };
 
   return (
     <div className="min-h-full flex items-center gap-6 justify-center py-12 px-6 sm:px-8 lg:px-10">

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,10 +1,14 @@
 import { Navigate, useLocation } from 'react-router';
-import getToken from '../utils/getToken';
+import { useRecoilValue } from 'recoil';
+import { userState } from '../states/recoil-states';
+// import getToken from '../utils/getToken';
 
 export default function RequireAuth({ children }: { children: JSX.Element }) {
+  const user = useRecoilValue(userState);
+
   const location = useLocation();
 
-  if (!getToken()) {
+  if (!user) {
     return <Navigate to='/login' state={{ from: location }} replace />;
   }
 

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -102,7 +102,7 @@ export default function SignUp() {
 
                 localStorage.setItem('alexandria-user-token', loggedInUser.token);
 
-                navigate('/texts');
+                navigate('/verify');
               }
             })
           }>

--- a/src/components/Verify.tsx
+++ b/src/components/Verify.tsx
@@ -68,7 +68,7 @@ export default function Verified() {
                 </span>
               </h2>
               <div className="text-md mt-4 text-secondary">
-                <p className="pb-2">That means you have a can look around but won't be able to add your own texts.</p>
+                <p className="pb-2">That means you can have a look around but won't be able to add your own texts.</p>
                 <p className="pb-2">We have sent an email to the address you gave us when you signed up.<br/>
                    Please click the link in that email to verify your address.<br/>
                    Don't forget to check your spam folder and look for <em>read.with.alexandria</em>.</p>
@@ -84,6 +84,13 @@ export default function Verified() {
                         Mail sent
                       </button>
                   }
+                </div>
+                <div className="mt-12 ml-8 inline-flex rounded-md shadow">
+                  <Link to="/texts">
+                    <button type="button" className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-fuchsia-800 hover:bg-fuchsia-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sky-500">
+                      Look around
+                    </button>
+                  </Link>
                 </div>
               </div>
             </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,19 +16,16 @@ import SignUp from './components/SignUp';
 import NotFound from './components/NotFound';
 import SingleText from './components/texts/SingleText';
 import UserTexts from './components/texts/UserTexts';
+import TextForm from './components/texts/TextForm';
 import PrivateRoute from './components/PrivateRoute';
 import Verify from './components/Verify';
 
-import getToken from './utils/getToken';
-
 import './index.css';
 import './App.css';
-import TextForm from './components/texts/TextForm';
 
 <link href="/dist/output.css" rel="stylesheet"></link>;
 
 const rootElement = document.getElementById('root');
-const token = getToken();
 
 render(
   <React.StrictMode>
@@ -36,7 +33,7 @@ render(
       <Router>
         <Routes>
           <Route path="/" element={<App />}>
-            <Route index element={token ? <UserTexts /> : < Home />}/>
+            <Route index element={< Home />}/>
             <Route path="texts" element={<PrivateRoute><UserTexts /></PrivateRoute>}/>
               <Route path="texts/new" element={<PrivateRoute><TextForm /></PrivateRoute>}/>
               <Route path="texts/edit" element={<PrivateRoute><TextForm /></PrivateRoute>}/>
@@ -46,7 +43,7 @@ render(
             <Route path="logout" element={<Home />} />
             <Route path="settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
             <Route path="about" element={<About />} />
-            <Route path="login" element={token ? <UserTexts /> : <LogIn />} />
+            <Route path="login" element={<LogIn />} />
             <Route path="signup" element={<SignUp />} />
             <Route path="verify" element={<PrivateRoute><Verify /></PrivateRoute>} />
             <Route path="*" element={<NotFound />}/>


### PR DESCRIPTION
## Description

This update can handle invalid tokens in `localStorage`. 

Redirection is no longer done in `index.tsx` based on the existence of a token. 

Instead, `Login.tsx` and `Home.tsx` `Navigate` to the `/texts` route if a `userState` is set. 

`App.tsx` handles invalid token and deletes them after receiving an error from the server. 

It works almost as before, only on reload or direct route access you might see the login route flash in the address bar of the browser. 

## Related Issue

Closes #229 

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|  :heavy_check_mark:    | :hammer: Refactoring       |
