### PR TITLE
paste text from clipboard

### DIFF
--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -302,6 +302,10 @@ const TranslationComponent = function({ word }:
                   <input
                     type="text"
                     id="translation"
+                    onClick={async (event) => {
+                      const target = event.currentTarget;
+                      target.value = await navigator.clipboard.readText();
+                    }}
                     onChange={(event) => handleInput(event)}
                     value={translation}
                     className=" focus:border focus:border-sky-600 bg-four dark:border-transparent focus:ring-0 flex-1 block w-full rounded-none rounded-l-md sm:text-sm border-gray-300"


### PR DESCRIPTION
## Description

Tried out an idea: clicking on the translation text input pastes text currently in clipboard. Might make use on mobile easier. Have to test.

(I didn't mark this "draft" so I would get a preview app out of it.)

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
| :heavy_check_mark:     | :sparkles: New feature     |
