### PR TITLE
Dictionary bug fix and status visibility change

### DIFF
--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -263,12 +263,13 @@ const TranslationComponent = function({ word }:
   };
 
   useEffect(() => {
+    console.log(currentWord);
     if (currentWord?.translations.length === 0) {
       setShowDictionary(true);
     } else if (showDictionary) {
       setShowDictionary(false);
     }
-  }, [currentWord]);
+  }, [currentWord?.word]);
 
 
   const regex = new RegExp(`\\b${currentWord?.word}\\b`, 'gui');
@@ -335,7 +336,8 @@ const TranslationComponent = function({ word }:
         </div>
       </div>
       <div className='flex flex-row justify-center'>
-      {!showDictionary && <ChangeStatus word={word} />}
+      {/* {!showDictionary && <ChangeStatus word={word} />} */}
+      {<ChangeStatus word={word} />}
       </div>
       </>}
     </div>


### PR DESCRIPTION
## Description

Fixed bug where dictionary opened when changing status. Status is now always visible

## Related Issue

closes #251 

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| X  | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Testing Steps / QA Criteria

Click a word, close the dictionary, change the status. The Dictionary should stay closed. The status bar should be visible even when dictionary is open.
