### PR TITLE
Fixed a bug where phrases weren't selected in firefox

### DIFF
--- a/src/components/texts/Phrase-Word.tsx
+++ b/src/components/texts/Phrase-Word.tsx
@@ -32,10 +32,12 @@ export const Word = function ({ word, dataKey, context }:
     const selection = window.getSelection();
 
     if (selection?.toString() && selection !== null) {
-      const selectedString = selection.toString();
+      // console.log();
+      const selectedString = selection.getRangeAt(0).cloneContents().textContent || '';
 
       const startNode = selection.anchorNode;
       const endNode = selection.focusNode;
+
       const stringArray = selectedString.split(' ');
 
       // ensures the first and last words are whole words

--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -290,7 +290,6 @@ const TranslationComponent = function({ word }:
   };
 
   useEffect(() => {
-    console.log(currentWord);
     if (currentWord?.translations.length === 0) {
       setShowDictionary(true);
     } else if (showDictionary) {
@@ -379,7 +378,7 @@ const TranslationInput = function({ voices }:
   const [userWords, setUserWords] = useRecoilState(userwordsState);
   const user = useRecoilValue(userState);
   const location = useLocation();
-  console.log(userWords);
+
   const isElement = function(element: Element | EventTarget): element is Element {
     return (element as Element).nodeName !== undefined;
   };


### PR DESCRIPTION
This still leaves the problem of punctuation getting messed up, especially if the selection is backwards and the punctuation is on the first work.

But it solves the main problem of phrases not getting selected on Firefox.