### PR TITLE
mh selection experiment

### DIFF
--- a/src/components/texts/TranslationInput.tsx
+++ b/src/components/texts/TranslationInput.tsx
@@ -290,7 +290,7 @@ const TranslationComponent = function({ word }:
   };
 
   useEffect(() => {
-    if (currentWord?.translations.length === 0) {
+    if (currentWord?.translations.length === 0 && currentWord.word.split(' ').length < 2) {
       setShowDictionary(true);
     } else if (showDictionary) {
       setShowDictionary(false);


### PR DESCRIPTION
## Description

* Rewrote the phrase selection without word-swapping.
* When selection is backwards, latter part of selection is kept, so you always keep where you began your selection. 
* Since WordReference has hardly any translations for phrases I turned off the automatic opening of the dictionary `iframe` for phrases. 

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
| ✔️     | :sparkles: New feature     |
| ✔️     | :hammer: Refactoring       |

## Testing Steps / QA Criteria

I tested this on Chrome and Firefox. More tests are needed on mobile devices with the preview app from this PR.